### PR TITLE
Update answered survey posts based on UX feedback

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -119,6 +119,14 @@ func (p *Plugin) submitScore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user, err := p.API.GetUser(userID)
+	if err != nil {
+		p.API.LogError("Failed to get user", "user_id", userID, "err", err)
+
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	var score int
 	if i, err := strconv.ParseInt(surveyResponse.Context["selected_option"].(string), 10, 0); err != nil {
 		p.API.LogError("Score response contains invalid score")
@@ -136,11 +144,11 @@ func (p *Plugin) submitScore(w http.ResponseWriter, r *http.Request) {
 
 	p.sendScore(score, userID, time.Now().UnixNano()/int64(time.Millisecond))
 
-	p.CreateBotDMPost(userID, p.buildFeedbackRequestPost(userID))
+	p.CreateBotDMPost(userID, p.buildFeedbackRequestPost())
 
 	// Send response to update score post
 	response := model.PostActionIntegrationResponse{
-		Update: p.buildAnsweredSurveyPost(score),
+		Update: p.buildAnsweredSurveyPost(user, score),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/survey.go
+++ b/server/survey.go
@@ -340,17 +340,23 @@ func (p *Plugin) buildSurveyPost(user *model.User) *model.Post {
 	}
 }
 
-func (p *Plugin) buildAnsweredSurveyPost(score int) *model.Post {
+func (p *Plugin) buildAnsweredSurveyPost(user *model.User, score int) *model.Post {
 	return &model.Post{
 		Type:    "custom_nps_survey",
-		Message: fmt.Sprintf(surveyAnsweredBody, score),
+		Message: fmt.Sprintf(surveyBody, user.Username),
 		Props: map[string]interface{}{
+			"attachments": []*model.SlackAttachment{
+				{
+					Title: surveyDropdownTitle,
+					Text:  fmt.Sprintf(surveyAnsweredBody, score),
+				},
+			},
 			"from_webhook": true, // Needs to be manually specified since this doesn't go through CreateBotDMPost
 		},
 	}
 }
 
-func (p *Plugin) buildFeedbackRequestPost(userID string) *model.Post {
+func (p *Plugin) buildFeedbackRequestPost() *model.Post {
 	return &model.Post{
 		Type:    "custom_nps_feedback",
 		Message: feedbackRequestBody,


### PR DESCRIPTION
Previously, answered survey posts would just be replaced by plain text
![image](https://user-images.githubusercontent.com/3277310/54782178-9d9e2000-4bf4-11e9-8985-8e1515c006ec.png)
but that made it a bit difficult to see that Surveybot asked for written feedback. We're changing it to keep the message attachment box so that the transition is a bit less jarring and hopefully make it more obvious that there was a followup question
![image](https://user-images.githubusercontent.com/3277310/54782231-c0c8cf80-4bf4-11e9-8d83-aae57bb814d3.png)
