### PR TITLE
Use min_server_version instead of selfwritten solution

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,7 @@
     "name": "Net Promoter Score",
     "description": "This plugin sends Net Promoter Score surveys to gather user feedback on Mattermost.",
     "version": "0.0.1",
+    "min_server_version": "5.10.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/activate.go
+++ b/server/activate.go
@@ -6,16 +6,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var minimumServerVersion = semver.MustParse("5.9.0") // TODO change this to 5.10.0
-
-func checkMinimumVersion(serverVersion semver.Version) error {
-	if serverVersion.LT(minimumServerVersion) {
-		return errors.New("NPS plugin can only be ran on Mattermost 5.10.0 or higher")
-	}
-
-	return nil
-}
-
 func (p *Plugin) OnActivate() error {
 	p.API.LogDebug("Activating NPS plugin")
 
@@ -28,10 +18,6 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrap(err, "failed to parse server version")
 	} else {
 		p.serverVersion = serverVersion
-	}
-
-	if err := checkMinimumVersion(p.serverVersion); err != nil {
-		return errors.Wrap(err, "failed to check minimum server version")
 	}
 
 	if err := p.ensureBotExists(); err != nil {


### PR DESCRIPTION
Use https://developers.mattermost.com/extend/plugins/manifest-reference/#min_server_version instead of self written solution.

This needs to be merged after the server version has been bumped, which will happen in a few days.