### PR TITLE
MM-14553 Add nps-test command and refactor for test build

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -40,6 +40,8 @@ func (p *Plugin) OnActivate() error {
 
 	p.initializeClient()
 
+	p.registerCommands()
+
 	p.API.LogDebug("NPS plugin activated")
 
 	p.checkForNextSurvey(p.serverVersion)

--- a/server/survey.go
+++ b/server/survey.go
@@ -14,16 +14,19 @@ import (
 const (
 	// How often "survey scheduled" emails can be sent to prevent multiple emails from being sent if multiple server
 	// upgrades occur within a short time
-	MIN_DAYS_BETWEEN_SURVEY_EMAILS = 7
+	MIN_TIME_BETWEEN_SURVEY_EMAILS = 7 * 24 * time.Hour
 
-	// How long until a survey occurs after a server upgrade
+	// How long until a survey occurs after a server upgrade in days (for use in notifications)
 	DAYS_UNTIL_SURVEY = 21
+
+	// How long until a survey occurs after a server upgrade as a time.Duration
+	TIME_UNTIL_SURVEY = 21 * 24 * time.Hour
 
 	// Get admin users up to 100 at a time when sending email notifications
 	ADMIN_USERS_PER_PAGE = 100
 
 	// The minimum time before a user can be sent a survey after completing the previous one
-	MIN_DAYS_BETWEEN_USER_SURVEYS = 90
+	MIN_TIME_BETWEEN_USER_SURVEYS = 90 * 24 * time.Hour
 )
 
 type adminNotice struct {
@@ -46,7 +49,7 @@ func (p *Plugin) checkForNextSurvey(currentVersion semver.Version) bool {
 	}
 
 	now := time.Now().UTC()
-	nextSurvey := now.Add(DAYS_UNTIL_SURVEY * 24 * time.Hour)
+	nextSurvey := now.Add(TIME_UNTIL_SURVEY)
 
 	if lastUpgrade == nil {
 		p.API.LogInfo(fmt.Sprintf("NPS plugin installed. Scheduling NPS survey for %s", nextSurvey.Format("Jan 2, 2006")))
@@ -75,7 +78,7 @@ func shouldScheduleSurvey(currentVersion semver.Version, lastUpgrade *serverUpgr
 func shouldSendAdminNotices(now time.Time, lastUpgrade *serverUpgrade) bool {
 	// Only send a "survey scheduled" email if it has been at least 7 days since the last time we've sent one to
 	// prevent spamming admins when multiple upgrades are done within a short period.
-	return lastUpgrade == nil || now.Sub(lastUpgrade.Timestamp) >= MIN_DAYS_BETWEEN_SURVEY_EMAILS*24*time.Hour
+	return lastUpgrade == nil || now.Sub(lastUpgrade.Timestamp) >= MIN_TIME_BETWEEN_SURVEY_EMAILS
 }
 
 func (p *Plugin) sendAdminNotices(nextSurvey time.Time) {
@@ -239,12 +242,12 @@ func (p *Plugin) shouldSendSurveyDM(user *model.User, now time.Time) bool {
 		return false
 	}
 
-	if now.Sub(lastUpgrade.Timestamp) < DAYS_UNTIL_SURVEY*24*time.Hour {
+	if now.Sub(lastUpgrade.Timestamp) < TIME_UNTIL_SURVEY {
 		return false
 	}
 
 	// And the user has existed for at least as long
-	if now.Sub(time.Unix(user.CreateAt/1000, 0)) < DAYS_UNTIL_SURVEY*24*time.Hour {
+	if now.Sub(time.Unix(user.CreateAt/1000, 0)) < TIME_UNTIL_SURVEY {
 		return false
 	}
 
@@ -265,12 +268,12 @@ func (p *Plugin) shouldSendSurveyDM(user *model.User, now time.Time) bool {
 		return false
 	}
 
-	if now.Sub(state.SentAt) < MIN_DAYS_BETWEEN_USER_SURVEYS*24*time.Hour {
+	if now.Sub(state.SentAt) < MIN_TIME_BETWEEN_USER_SURVEYS {
 		// Not enough time since last survey was sent
 		return false
 	}
 
-	if now.Sub(state.AnsweredAt) < MIN_DAYS_BETWEEN_USER_SURVEYS*24*time.Hour {
+	if now.Sub(state.AnsweredAt) < MIN_TIME_BETWEEN_USER_SURVEYS {
 		// Not enough time since last survey was completed
 		return false
 	}

--- a/server/test_commands.go
+++ b/server/test_commands.go
@@ -66,7 +66,7 @@ func (p *Plugin) executeTestCommand(action string, args []string) (*model.Comman
 	if action == "" {
 		return &model.CommandResponse{
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			Text:         "No action specified.",
+			Text:         fmt.Sprintf("Unknown action %s specified.", action),
 		}, nil
 	}
 
@@ -105,7 +105,7 @@ func (p *Plugin) executeTestResetCommand(args []string) (*model.CommandResponse,
 
 	return &model.CommandResponse{
 		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-		Text:         "NPS plugin reset. Please re-enable it from the system console to continue testing.",
+		Text:         "NPS plugin reset. Please disable and re-enable it from the system console to continue testing.",
 	}, nil
 }
 
@@ -117,11 +117,24 @@ func (p *Plugin) executeTestVersionCommand(args []string) (*model.CommandRespons
 		}, nil
 	}
 
-	version := semver.MustParse(args[0])
+	version, err := semver.Parse(args[0])
+	if err != nil {
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         fmt.Sprintf("Invalid version %s specified.", args[0]),
+		}, nil
+	}
 
 	var timestamp time.Time
 	if len(args) == 2 {
-		t, _ := strconv.ParseInt(args[1], 10, 64)
+		t, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			return &model.CommandResponse{
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+				Text:         fmt.Sprintf("Invalid unix timestamp %s specified.", args[1]),
+			}, nil
+		}
+
 		timestamp = time.Unix(t, 0).UTC()
 	} else {
 		timestamp = time.Now().UTC()

--- a/server/test_commands.go
+++ b/server/test_commands.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
+)
+
+const (
+	// ENABLE_TEST_COMMANDS can be set to true at compile time to enable some additional testing commands.
+	ENABLE_TEST_COMMANDS = false
+
+	COMMAND_TEST         = "nps-test"
+	COMMAND_TEST_RESET   = "reset"
+	COMMAND_TEST_VERSION = "version"
+)
+
+func (p *Plugin) registerCommands() {
+	if ENABLE_TEST_COMMANDS {
+		p.API.RegisterCommand(&model.Command{
+			Trigger: COMMAND_TEST,
+		})
+	}
+}
+
+func parseCommandArgs(commandArgs *model.CommandArgs) (string, string, []string) {
+	split := strings.Fields(commandArgs.Command)
+
+	command := ""
+	if len(split) > 0 {
+		command = split[0]
+
+		// Trim the leading slash
+		command = command[1:]
+	}
+
+	action := ""
+	if len(split) > 1 {
+		action = split[1]
+	}
+
+	var args []string
+	if len(split) > 2 {
+		args = split[2:]
+	}
+
+	return command, action, args
+}
+
+func (p *Plugin) ExecuteCommand(c *plugin.Context, commandArgs *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	command, action, args := parseCommandArgs(commandArgs)
+
+	if ENABLE_TEST_COMMANDS && command == COMMAND_TEST {
+		return p.executeTestCommand(action, args)
+	}
+
+	return nil, nil
+}
+
+func (p *Plugin) executeTestCommand(action string, args []string) (*model.CommandResponse, *model.AppError) {
+	if action == "" {
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         "No action specified.",
+		}, nil
+	}
+
+	commands := map[string]func([]string) (*model.CommandResponse, *model.AppError){
+		COMMAND_TEST_RESET:   p.executeTestResetCommand,
+		COMMAND_TEST_VERSION: p.executeTestVersionCommand,
+	}
+
+	command, ok := commands[action]
+	if !ok {
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         "Incorrect action specified.",
+		}, nil
+	}
+
+	return command(args)
+}
+
+func (p *Plugin) executeTestResetCommand(args []string) (*model.CommandResponse, *model.AppError) {
+	if err := p.API.KVDeleteAll(); err != nil {
+		p.API.LogError("Failed to reset plugin state", "err", err)
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         "Failed to reset plugin state. See log for more details.",
+		}, nil
+	}
+
+	if err := p.API.KVSet(BOT_USER_KEY, []byte(p.botUserId)); err != nil {
+		p.API.LogError("Failed to restore bot user ID after resetting plugin state", "err", err)
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         "Failed to re-add bot user ID after resetting plugin state. This will likely render the plugin inoperable. See log for more details.",
+		}, nil
+	}
+
+	return &model.CommandResponse{
+		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		Text:         "NPS plugin reset. Please re-enable it from the system console to continue testing.",
+	}, nil
+}
+
+func (p *Plugin) executeTestVersionCommand(args []string) (*model.CommandResponse, *model.AppError) {
+	if len(args) == 0 || len(args) > 2 {
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         "Wrong number of params specified. Expected `" + COMMAND_TEST + " " + COMMAND_TEST_RESET + " <version> [<unix timestamp of upgrade>]`.",
+		}, nil
+	}
+
+	version := semver.MustParse(args[0])
+
+	var timestamp time.Time
+	if len(args) == 2 {
+		t, _ := strconv.ParseInt(args[1], 10, 64)
+		timestamp = time.Unix(t, 0).UTC()
+	} else {
+		timestamp = time.Now().UTC()
+	}
+
+	if err := p.storeServerUpgrade(&serverUpgrade{
+		Version:   version,
+		Timestamp: timestamp,
+	}); err != nil {
+		p.API.LogError("Failed to store server version", "err", err)
+		return &model.CommandResponse{
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			Text:         "Failed to store server version. See log for more details.",
+		}, nil
+	}
+
+	return &model.CommandResponse{
+		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		Text:         fmt.Sprintf("Stored server version set to %s as if the server was upgraded at %s. Disable and re-enable the plugin to simulate upgrade or refresh to attempt to trigger a survey.", version, timestamp),
+	}, nil
+}

--- a/server/test_commands.go
+++ b/server/test_commands.go
@@ -95,14 +95,6 @@ func (p *Plugin) executeTestResetCommand(args []string) (*model.CommandResponse,
 		}, nil
 	}
 
-	if err := p.API.KVSet(BOT_USER_KEY, []byte(p.botUserId)); err != nil {
-		p.API.LogError("Failed to restore bot user ID after resetting plugin state", "err", err)
-		return &model.CommandResponse{
-			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			Text:         "Failed to re-add bot user ID after resetting plugin state. This will likely render the plugin inoperable. See log for more details.",
-		}, nil
-	}
-
 	return &model.CommandResponse{
 		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 		Text:         "NPS plugin reset. Please disable and re-enable it from the system console to continue testing.",

--- a/server/test_commands.go
+++ b/server/test_commands.go
@@ -66,7 +66,7 @@ func (p *Plugin) executeTestCommand(action string, args []string) (*model.Comman
 	if action == "" {
 		return &model.CommandResponse{
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			Text:         fmt.Sprintf("Unknown action %s specified.", action),
+			Text:         "No action specified.",
 		}, nil
 	}
 
@@ -79,7 +79,7 @@ func (p *Plugin) executeTestCommand(action string, args []string) (*model.Comman
 	if !ok {
 		return &model.CommandResponse{
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-			Text:         "Incorrect action specified.",
+			Text:         fmt.Sprintf("Unknown action %s specified.", action),
 		}, nil
 	}
 


### PR DESCRIPTION
The `nps-test` command will be controlled by a constant, so the test build will have to be manually generated. The other refactoring is just to give me some easy constants when changing some times to allow for QA to test within a reasonable amount of time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14553