### PR TITLE
Use plugin ID from manifest for API calls

### DIFF
--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -1,6 +1,8 @@
+import {id as pluginId} from './manifest';
+
 export class Client {
     constructor() {
-        this.url = '/plugins/com.mattermost.nps/api/v1';
+        this.url = `/plugins/${pluginId}/api/v1`;
     }
 
     connected = () => {


### PR DESCRIPTION
This is needed for the test build, but since I'm compiling that manually, this doesn't need to go into the version shipped in 5.10