### PR TITLE
 Add a random delay before handling events to mitigate against race conditions

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -63,8 +63,7 @@ func (p *Plugin) canSendDiagnostics() bool {
 func (p *Plugin) ensureBotExists() (string, *model.AppError) {
 	// Attempt to find an existing bot
 	var botUserId string
-	appErr := p.KVGet(BOT_USER_KEY, &botUserId)
-	if appErr != nil {
+	if appErr := p.KVGet(BOT_USER_KEY, &botUserId); appErr != nil {
 		return "", appErr
 	}
 
@@ -85,17 +84,17 @@ func (p *Plugin) ensureBotExists() (string, *model.AppError) {
 		// Unable to create the bot, so it may already exist and need to be reclaimed
 		p.API.LogDebug("Failed to create bot for NPS plugin. Attempting to reclaim existing bot.")
 
-		user, appErr := p.API.GetUserByUsername("surveybot")
-		if appErr != nil || user == nil {
-			return "", appErr
+		user, err := p.API.GetUserByUsername("surveybot")
+		if err != nil || user == nil {
+			return "", err
 		}
 
 		// A surveybot user exists, so try to reclaim the existing bot account
 		p.API.LogDebug("Found surveybot user. Attempting to find matching bot account.")
 
-		bot, appErr = p.API.GetBot(user.Id, true)
-		if appErr != nil {
-			return "", appErr
+		bot, err = p.API.GetBot(user.Id, true)
+		if err != nil {
+			return "", err
 		}
 
 		p.API.LogInfo("Found existing bot account")

--- a/server/activate.go
+++ b/server/activate.go
@@ -23,11 +23,11 @@ func (p *Plugin) OnActivate() error {
 		p.serverVersion = serverVersion
 	}
 
-	if botUserId, err := p.ensureBotExists(); err != nil {
+	botUserId, err := p.ensureBotExists()
+	if err != nil {
 		return errors.Wrap(err, "failed to ensure bot user exists")
-	} else {
-		p.botUserId = botUserId
 	}
+	p.botUserId = botUserId
 
 	p.initializeClient()
 
@@ -42,16 +42,10 @@ func (p *Plugin) OnActivate() error {
 }
 
 func (p *Plugin) setActivated(activated bool) {
-	p.activatedLock.Lock()
-	defer p.activatedLock.Unlock()
-
 	p.activated = activated
 }
 
 func (p *Plugin) isActivated() bool {
-	p.activatedLock.RLock()
-	defer p.activatedLock.RUnlock()
-
 	return p.activated
 }
 

--- a/server/activate.go
+++ b/server/activate.go
@@ -35,7 +35,7 @@ func (p *Plugin) OnActivate() error {
 	p.setActivated(true)
 	p.API.LogDebug("NPS plugin activated")
 
-	p.checkForNextSurvey(p.serverVersion)
+	go p.checkForNextSurvey(p.serverVersion)
 
 	return nil
 }

--- a/server/activate_test.go
+++ b/server/activate_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEnsureBotExists(t *testing.T) {
+	setupAPI := func() *plugintest.API {
+		api := &plugintest.API{}
+		api.On("LogDebug", mock.Anything).Maybe()
+		api.On("LogInfo", mock.Anything).Maybe()
+		return api
+	}
+
+	t.Run("should return error if unable to read KV store", func(t *testing.T) {
+		expectedErr := &model.AppError{Message: "Something went wrong"}
+
+		api := setupAPI()
+		api.On("KVGet", BOT_USER_KEY).Return(nil, expectedErr)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.API = api
+
+		botId, err := p.ensureBotExists()
+
+		assert.Equal(t, "", botId)
+		assert.Equal(t, expectedErr, err)
+	})
+
+	t.Run("should return the stored bot ID", func(t *testing.T) {
+		expectedBotId := model.NewId()
+
+		api := setupAPI()
+		api.On("KVGet", BOT_USER_KEY).Return(mustMarshalJSON(expectedBotId), nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.API = api
+
+		botId, err := p.ensureBotExists()
+
+		assert.Equal(t, expectedBotId, botId)
+		assert.Nil(t, err)
+	})
+
+	t.Run("if a bot already exists, but is not in the KV store", func(t *testing.T) {
+		t.Run("should return an error if unable to get surveybot user", func(t *testing.T) {
+			expectedError := &model.AppError{
+				Message: "Unable to get surveybot user",
+			}
+
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(nil, &model.AppError{})
+			api.On("GetUserByUsername", "surveybot").Return(nil, expectedError)
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, "", botId)
+			assert.Equal(t, expectedError, err)
+		})
+
+		t.Run("should return an error if unable to get bot", func(t *testing.T) {
+			expectedBotId := model.NewId()
+			expectedError := &model.AppError{
+				Message: "Unable to get bot",
+			}
+
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(nil, &model.AppError{})
+			api.On("GetUserByUsername", "surveybot").Return(&model.User{
+				Id: expectedBotId,
+			}, nil)
+			api.On("GetBot", expectedBotId, true).Return(nil, expectedError)
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, "", botId)
+			assert.Equal(t, expectedError, err)
+		})
+
+		t.Run("should find and return the existing bot ID", func(t *testing.T) {
+			expectedBotId := model.NewId()
+
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(nil, &model.AppError{})
+			api.On("GetUserByUsername", "surveybot").Return(&model.User{
+				Id: expectedBotId,
+			}, nil)
+			api.On("GetBot", expectedBotId, true).Return(&model.Bot{
+				UserId: expectedBotId,
+			}, nil)
+			api.On("KVSet", BOT_USER_KEY, mustMarshalJSON(expectedBotId)).Return(nil)
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, expectedBotId, botId)
+			assert.Nil(t, err)
+		})
+	})
+
+	t.Run("if a bot doesn't already exist", func(t *testing.T) {
+		t.Run("should return an error if unable to get the bundle path", func(t *testing.T) {
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(&model.Bot{
+				UserId: model.NewId(),
+			}, nil)
+			api.On("GetBundlePath").Return("", &model.AppError{})
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, "", botId)
+			assert.NotNil(t, err)
+		})
+
+		t.Run("should return an error if unable to read the profile picture", func(t *testing.T) {
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(&model.Bot{
+				UserId: model.NewId(),
+			}, nil)
+			api.On("GetBundlePath").Return("", nil)
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{
+				readFile: func(path string) ([]byte, error) {
+					return nil, &model.AppError{}
+				},
+			}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, "", botId)
+			assert.NotNil(t, err)
+		})
+
+		t.Run("should log a warning if unable to set the profile picture, but still return the bot", func(t *testing.T) {
+			expectedBotId := model.NewId()
+			profileImageBytes := []byte("profileImage")
+			expectedError := &model.AppError{
+				Message: "Unable to set profile picture",
+			}
+
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(&model.Bot{
+				UserId: expectedBotId,
+			}, nil)
+			api.On("GetBundlePath").Return("", nil)
+			api.On("SetProfileImage", expectedBotId, profileImageBytes).Return(expectedError)
+			api.On("LogWarn", mock.Anything, mock.Anything, expectedError)
+			api.On("KVSet", BOT_USER_KEY, mustMarshalJSON(expectedBotId)).Return(nil)
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{
+				readFile: func(path string) ([]byte, error) {
+					return profileImageBytes, nil
+				},
+			}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, expectedBotId, botId)
+			assert.Nil(t, err)
+		})
+
+		t.Run("should create the bot and return the ID", func(t *testing.T) {
+			expectedBotId := model.NewId()
+			profileImageBytes := []byte("profileImage")
+
+			api := setupAPI()
+			api.On("KVGet", BOT_USER_KEY).Return(nil, nil)
+			api.On("CreateBot", mock.Anything).Return(&model.Bot{
+				UserId: expectedBotId,
+			}, nil)
+			api.On("GetBundlePath").Return("", nil)
+			api.On("SetProfileImage", expectedBotId, profileImageBytes).Return(nil)
+			api.On("KVSet", BOT_USER_KEY, mustMarshalJSON(expectedBotId)).Return(nil)
+			defer api.AssertExpectations(t)
+
+			p := &Plugin{
+				readFile: func(path string) ([]byte, error) {
+					return profileImageBytes, nil
+				},
+			}
+			p.API = api
+
+			botId, err := p.ensureBotExists()
+
+			assert.Equal(t, expectedBotId, botId)
+			assert.Nil(t, err)
+		})
+	})
+}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -85,7 +85,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	if p.isActivated() {
 		if configuration.EnableSurvey && !oldConfiguration.EnableSurvey {
 			// Check if a survey needs to be sent when the survey is enabled
-			p.checkForNextSurvey(p.serverVersion)
+			go p.checkForNextSurvey(p.serverVersion)
 		}
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	plugin.ClientMain(&Plugin{})
+	plugin.ClientMain(NewPlugin())
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	ADMIN_DM_NOTICE_KEY = "AdminDM-"
-	BOT_USER_KEY        = "Bot"
 	SERVER_UPGRADE_KEY  = "ServerUpgrade"
 	USER_SURVEY_KEY     = "UserSurvey-"
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"sync"
 	"time"
 
@@ -57,11 +58,16 @@ type Plugin struct {
 	// userSurveyMaxDelay adds a short delay when checking whether the user needs to receive DMs notifying them of a new
 	// NPS survey.
 	userSurveyMaxDelay time.Duration
+
+	// readFile provides access to ioutil.ReadFile in a way that is mockable for unit testing.
+	readFile func(path string) ([]byte, error)
 }
 
 func NewPlugin() *Plugin {
 	return &Plugin{
 		upgradeCheckMaxDelay: DEFAULT_UPGRADE_CHECK_MAX_DELAY,
 		userSurveyMaxDelay:   DEAFULT_USER_SURVEY_MAX_DELAY,
+
+		readFile: ioutil.ReadFile,
 	}
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -19,7 +19,7 @@ const (
 	SURVEYBOT_DESCRIPTION = "Surveybot collects user feedback to improve Mattermost. [Learn more](https://mattermost.com/pl/default-nps)."
 
 	DEFAULT_UPGRADE_CHECK_MAX_DELAY = 2 * time.Minute
-	DEAFULT_USER_SURVEY_MAX_DELAY   = 1 * time.Second
+	DEAFULT_USER_SURVEY_MAX_DELAY   = 3 * time.Second
 )
 
 type Plugin struct {
@@ -31,9 +31,6 @@ type Plugin struct {
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
 	configuration *configuration
-
-	// activatedLock synchronizes access to activated.
-	activatedLock sync.RWMutex
 
 	// activated is used to track whether or not OnActivate has initialized the plugin state.
 	activated bool

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sync"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/mattermost/mattermost-server/plugin"
@@ -15,6 +16,9 @@ const (
 	USER_SURVEY_KEY     = "UserSurvey-"
 
 	SURVEYBOT_DESCRIPTION = "Surveybot collects user feedback to improve Mattermost. [Learn more](https://mattermost.com/pl/default-nps)."
+
+	DEFAULT_UPGRADE_CHECK_MAX_DELAY = 2 * time.Minute
+	DEAFULT_USER_SURVEY_MAX_DELAY   = 1 * time.Second
 )
 
 type Plugin struct {
@@ -45,4 +49,19 @@ type Plugin struct {
 	botUserId string
 
 	client *analytics.Client
+
+	// upgradeCheckMaxDelay adds a short delay to checkForNextSurvey calls to mitigate against race conditions caused
+	// by multiple servers restarting at the same time after an upgrade.
+	upgradeCheckMaxDelay time.Duration
+
+	// userSurveyMaxDelay adds a short delay when checking whether the user needs to receive DMs notifying them of a new
+	// NPS survey.
+	userSurveyMaxDelay time.Duration
+}
+
+func NewPlugin() *Plugin {
+	return &Plugin{
+		upgradeCheckMaxDelay: DEFAULT_UPGRADE_CHECK_MAX_DELAY,
+		userSurveyMaxDelay:   DEAFULT_USER_SURVEY_MAX_DELAY,
+	}
 }

--- a/server/survey.go
+++ b/server/survey.go
@@ -40,6 +40,10 @@ type adminNotice struct {
 // Note that this only sends an email to admins to notify them that a survey has been scheduled. The web app plugin is
 // in charge of checking and actually triggering the survey.
 func (p *Plugin) checkForNextSurvey(currentVersion semver.Version) bool {
+	// Add a random delay to mitigate against the fact that multiple instances of the plugin may be trying to start up across
+	// different servers and we have no real way to synchronize between them.
+	p.sleepUpTo(p.upgradeCheckMaxDelay)
+
 	p.surveyLock.Lock()
 	defer p.surveyLock.Unlock()
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -63,6 +64,13 @@ func (p *Plugin) isBotDMChannel(channel *model.Channel) bool {
 	}
 
 	return true
+}
+
+func (p *Plugin) sleepUpTo(maxDelay time.Duration) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	delay := time.Duration(r.Int63n(int64(maxDelay)))
+
+	time.Sleep(delay)
 }
 
 // Test helper functions


### PR DESCRIPTION
This is based on https://github.com/mattermost/mattermost-plugin-nps/pull/25, so the changes specific to it are here: https://github.com/mattermost/mattermost-plugin-nps/compare/hh-disable-survey...hh-race.

Due to the lack of synchronization logic in the plugin API, we're adding a short delay before code paths that are likely to cause race conditions to reduce the chance that a race condition occurs in an HA environment where two plugin instances try to either schedule surveys or send survey DMs at the same time. While the delays are up to 2 minutes on a server upgrade or 1 second when checking if a survey DM needs to be sent, those should be significantly longer than either of those operations take, so the chances of two processes hitting each other there should be much lower when they're triggered at the same time.