### PR TITLE
MM-14854 Refactor plugin and add a bunch of unit tests

### DIFF
--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -102,8 +102,8 @@
   revision = "1d33003b386959af197ba96475f198c114627b5e"
 
 [[projects]]
-  branch = "release-5.10"
-  digest = "1:895e5e267bdfb83a59c87e35ddd1289ea8aa4c67692485df9a3776935f657984"
+  branch = "master"
+  digest = "1:849dc9b9e72ad7ae7733df878d90d3eb7eaf1e1d2912dffb90a0adb230956a34"
   name = "github.com/mattermost/mattermost-server"
   packages = [
     "mlog",
@@ -117,7 +117,7 @@
     "utils/markdown",
   ]
   pruneopts = "NUT"
-  revision = "cbf74d865ebb078691f6c54522d5d03df7fed1e9"
+  revision = "e5e1c5c027b8ba03d26bcbc56dc4077c6ee5cd58"
 
 [[projects]]
   digest = "1:18b773b92ac82a451c1276bd2776c1e55ce057ee202691ab33c8d6690efcc048"
@@ -205,11 +205,12 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:81d363777b015e85bd42b978b80f4f5ecdaa43e11452ba8ff7ea93db3ce166bd"
+  digest = "1:72cea38d2957d95d18be2287ef9d4b06b89796d2e3070bc7f796bea3a4844381"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "mock",
+    "require",
   ]
   pruneopts = "NUT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"

--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -392,7 +392,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/blang/semver",
     "github.com/mattermost/mattermost-server/model",
     "github.com/mattermost/mattermost-server/plugin",
     "github.com/mattermost/mattermost-server/plugin/plugintest",

--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -102,8 +102,7 @@
   revision = "1d33003b386959af197ba96475f198c114627b5e"
 
 [[projects]]
-  branch = "master"
-  digest = "1:849dc9b9e72ad7ae7733df878d90d3eb7eaf1e1d2912dffb90a0adb230956a34"
+  digest = "1:77c91150dbdad987cb9a3cce01cee3ebcfb05ab346f2e450009f4d2d6a53bf36"
   name = "github.com/mattermost/mattermost-server"
   packages = [
     "mlog",
@@ -117,7 +116,8 @@
     "utils/markdown",
   ]
   pruneopts = "NUT"
-  revision = "e5e1c5c027b8ba03d26bcbc56dc4077c6ee5cd58"
+  revision = "dc70ab42034da17eaf23be5a86abae81b3f1cd21"
+  version = "v5.10.0"
 
 [[projects]]
   digest = "1:18b773b92ac82a451c1276bd2776c1e55ce057ee202691ab33c8d6690efcc048"

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
-  branch = "master"
+  version = "~5.10.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
-  branch = "release-5.10"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/server/activate.go
+++ b/server/activate.go
@@ -23,6 +23,8 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.botUserID = botUserID
 
+	p.serverVersion = getServerVersion(p.API.GetServerVersion())
+
 	p.initializeClient()
 
 	p.API.LogDebug("NPS plugin activated")

--- a/server/activate.go
+++ b/server/activate.go
@@ -24,7 +24,10 @@ func (p *Plugin) OnActivate() error {
 
 	p.serverVersion = getServerVersion(p.API.GetServerVersion())
 
-	p.initializeClient()
+	if err := p.initializeClient(); err != nil {
+		p.API.LogError("Failed to initialize Segment client", "err", err.Error())
+		return err
+	}
 
 	p.API.LogDebug("NPS plugin activated")
 

--- a/server/activate.go
+++ b/server/activate.go
@@ -30,8 +30,9 @@ func (p *Plugin) OnActivate() error {
 
 	now := p.now().UTC()
 
-	upgraded, appErr := p.checkForServerUpgrade(now)
-	if upgraded {
+	if upgraded, appErr := p.checkForServerUpgrade(now); appErr != nil {
+		return appErr
+	} else if upgraded {
 		p.API.LogInfo("Upgrade detected. Checking if a survey should be scheduled.")
 
 		go p.checkForNextSurvey(now)

--- a/server/activate.go
+++ b/server/activate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"path/filepath"
-	"time"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
@@ -29,13 +28,13 @@ func (p *Plugin) OnActivate() error {
 
 	p.API.LogDebug("NPS plugin activated")
 
-	now := time.Now().UTC()
+	now := p.now().UTC()
 
 	upgraded, appErr := p.checkForServerUpgrade(now)
 	if upgraded {
 		p.API.LogInfo("Upgrade detected. Checking if a survey should be scheduled.")
 
-		go p.checkForNextSurvey(time.Now().UTC())
+		go p.checkForNextSurvey(now)
 	}
 
 	p.setActivated(true)

--- a/server/activate_test.go
+++ b/server/activate_test.go
@@ -1,13 +1,98 @@
 package main
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+func TestOnActivate(t *testing.T) {
+	botUserID := model.NewId()
+
+	makeAPIMock := func() *plugintest.API {
+		api := &plugintest.API{}
+		api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything).Maybe()
+		api.On("LogInfo", mock.Anything).Maybe()
+		return api
+	}
+
+	t.Run("should set up Plugin correctly", func(t *testing.T) {
+		now := toDate(2019, time.March, 1)
+		serverVersion := "5.10.0"
+
+		api := makeAPIMock()
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		api.On("CreateBot", mock.Anything).Return(nil, &model.AppError{})
+		api.On("GetUserByUsername", "surveybot").Return(&model.User{Id: botUserID}, nil)
+		api.On("GetBot", botUserID, true).Return(&model.Bot{UserId: botUserID}, nil)
+		api.On("GetServerVersion").Return(serverVersion)
+		api.On("KVGet", fmt.Sprintf(SERVER_UPGRADE_KEY, serverVersion)).Return(nil, &model.AppError{})
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			blockSegmentEvents: true,
+			now: func() time.Time {
+				return now
+			},
+		}
+		p.SetAPI(api)
+
+		err := p.OnActivate()
+
+		assert.Nil(t, err)
+
+		assert.Equal(t, botUserID, p.botUserID)
+		assert.Equal(t, serverVersion, p.serverVersion)
+		assert.NotNil(t, p.client)
+	})
+
+	t.Run("should return an error when get Surveybot", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		api.On("CreateBot", mock.Anything).Return(nil, &model.AppError{})
+		api.On("GetUserByUsername", "surveybot").Return(nil, &model.AppError{})
+		api.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.OnActivate()
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("should return an error when diagnostics are not enabled", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(false),
+			},
+		})
+		api.On("LogError", mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.OnActivate()
+
+		assert.NotNil(t, err)
+	})
+}
 
 func TestEnsureBotExists(t *testing.T) {
 	setupAPI := func() *plugintest.API {

--- a/server/api.go
+++ b/server/api.go
@@ -71,13 +71,6 @@ func (p *Plugin) checkForDMs(userID string) *model.AppError {
 			return err
 		}
 
-		serverVersion, err := p.GetServerVersion()
-		if err != nil {
-			return err
-		}
-
-		now := time.Now()
-
 		go func() {
 			// Add a random delay to mitigate against the fact that the user may have multiple sessions hitting this
 			// API at the same time across different servers.
@@ -86,8 +79,10 @@ func (p *Plugin) checkForDMs(userID string) *model.AppError {
 			p.connectedLock.Lock()
 			defer p.connectedLock.Unlock()
 
-			p.checkForAdminNoticeDM(user, serverVersion)
-			p.checkForSurveyDM(user, serverVersion, now)
+			now := time.Now()
+
+			p.checkForAdminNoticeDM(user)
+			p.checkForSurveyDM(user, now)
 		}()
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -85,7 +85,7 @@ func (p *Plugin) checkForDMs(userID string) *model.AppError {
 				p.sendAdminNoticeDM(user, notice)
 			}
 
-			if p.shouldSendSurveyDM(user, now) {
+			if p.shouldSendSurveyDM(user, p.getServerVersion(), now) {
 				p.sendSurveyDM(user, now)
 			}
 		}()

--- a/server/api.go
+++ b/server/api.go
@@ -147,14 +147,7 @@ func (p *Plugin) submitScore(w http.ResponseWriter, r *http.Request) {
 
 	p.sendScore(score, userID, now.UnixNano()/int64(time.Millisecond))
 
-	serverVersion, err := p.GetServerVersion()
-	if err != nil {
-		p.API.LogError("Failed to get server version when handling NPS survey score", "err", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if err := p.markSurveyAnswered(userID, serverVersion, now); err != nil {
+	if err := p.markSurveyAnswered(userID, now); err != nil {
 		p.API.LogWarn("Failed to mark survey as answered", "err", err)
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/pkg/errors"
 )
 
 type apiHandler func(w http.ResponseWriter, r *http.Request)
@@ -148,7 +149,7 @@ func getScore(selectedOption string) (int64, error) {
 	}
 
 	if score < 0 || score > 10 {
-		return 0, fmt.Errorf("score out of range")
+		return 0, errors.New("score out of range")
 	}
 
 	return score, nil

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1,8 +1,350 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestPlaceholder(t *testing.T) {
+func TestCheckForDMs(t *testing.T) {
+	userID := model.NewId()
+
+	t.Run("should do nothing with diagnostics disabled", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(false),
+			},
+		})
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		err := p.checkForDMs(userID)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("should return error if unable to get user", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		api.On("GetUser", userID).Return(nil, &model.AppError{})
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		err := p.checkForDMs(userID)
+
+		assert.NotNil(t, err)
+	})
+
+	// The rest of this functionality is tested by TestCheckForAdminNoticeDM and TestCheckForSurveyDM
+}
+
+func TestSubmitScore(t *testing.T) {
+	botUserID := model.NewId()
+	userID := model.NewId()
+	userSurveyKey := fmt.Sprintf(USER_SURVEY_KEY, userID)
+
+	now := toDate(2018, time.April, 1)
+
+	makeAPIMock := func() *plugintest.API {
+		api := &plugintest.API{}
+		api.On("LogDebug", mock.Anything).Maybe()
+
+		// Disabling diagnostics allows the handler to run, but prevents data from being sent to Segment
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(false),
+			},
+		}).Maybe()
+
+		return api
+	}
+
+	t.Run("should send score to segment, respond for additional feedback, and update the score post", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetUser", userID).Return(&model.User{
+			Id: userID,
+		}, nil)
+		api.On("KVGet", userSurveyKey).Return(mustMarshalJSON(&userSurveyState{}), nil)
+		api.On("KVSet", userSurveyKey, mustMarshalJSON(&userSurveyState{
+			AnsweredAt: now,
+		})).Return(nil)
+		api.On("GetDirectChannel", userID, botUserID).Return(&model.Channel{}, nil)
+		api.On("CreatePost", mock.Anything).Return(&model.Post{}, nil)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{
+			botUserID: botUserID,
+			now: func() time.Time {
+				return now
+			},
+		}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", bytes.NewReader(mustMarshalJSON(&model.PostActionIntegrationRequest{
+			Context: map[string]interface{}{
+				"selected_option": "10",
+			},
+		})))
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+		body, _ := ioutil.ReadAll(result.Body)
+
+		assert.Equal(t, http.StatusOK, result.StatusCode)
+		assert.IsType(t, &model.PostActionIntegrationResponse{}, mustUnmarshalJSON(body, &model.PostActionIntegrationResponse{}))
+	})
+
+	t.Run("should only log warning if unable to mark survey answered", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetUser", userID).Return(&model.User{
+			Id: userID,
+		}, nil)
+		api.On("KVGet", userSurveyKey).Return(nil, &model.AppError{})
+		api.On("LogWarn", mock.Anything, mock.Anything, mock.Anything)
+		api.On("GetDirectChannel", userID, botUserID).Return(&model.Channel{}, nil)
+		api.On("CreatePost", mock.Anything).Return(&model.Post{}, nil)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{
+			botUserID: botUserID,
+			now: func() time.Time {
+				return now
+			},
+		}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", bytes.NewReader(mustMarshalJSON(&model.PostActionIntegrationRequest{
+			Context: map[string]interface{}{
+				"selected_option": "10",
+			},
+		})))
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+		body, _ := ioutil.ReadAll(result.Body)
+
+		assert.Equal(t, http.StatusOK, result.StatusCode)
+		assert.IsType(t, &model.PostActionIntegrationResponse{}, mustUnmarshalJSON(body, &model.PostActionIntegrationResponse{}))
+	})
+
+	t.Run("should return bad request if score is missing or invalid", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetUser", userID).Return(&model.User{
+			Id: userID,
+		}, nil)
+		api.On("LogError", mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", bytes.NewReader(mustMarshalJSON(&model.PostActionIntegrationRequest{
+			Context: map[string]interface{}{
+				"selected_option": "hmm",
+			},
+		})))
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+	})
+
+	t.Run("should return error if unable to get user", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetUser", userID).Return(nil, &model.AppError{})
+		api.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", bytes.NewReader(mustMarshalJSON(&model.PostActionIntegrationRequest{
+			Context: map[string]interface{}{
+				"selected_option": "10",
+			},
+		})))
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+
+		assert.Equal(t, http.StatusInternalServerError, result.StatusCode)
+	})
+
+	t.Run("should return bad request if request context is missing", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("LogError", mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", bytes.NewReader(mustMarshalJSON(&model.PostActionIntegrationRequest{})))
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+	})
+
+	t.Run("should return bad request if request body is invalid", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("LogError", mock.Anything, mock.Anything, mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", bytes.NewReader([]byte("garbage")))
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+	})
+
+	t.Run("should return bad request if request body is empty", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("LogError", mock.Anything, mock.Anything, mock.Anything)
+		defer api.AssertExpectations(t)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/score", nil)
+		request.Header.Set("Mattermost-User-ID", userID)
+
+		p.submitScore(recorder, request)
+
+		result := recorder.Result()
+
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+	})
+}
+
+func TestGetScore(t *testing.T) {
+	for _, test := range []struct {
+		Name           string
+		SelectedOption string
+		ExpectedScore  int64
+		ExpectError    bool
+	}{
+		{
+			Name:           "a number",
+			SelectedOption: "7",
+			ExpectedScore:  7,
+		},
+		{
+			Name:           "zero",
+			SelectedOption: "0",
+			ExpectedScore:  0,
+		},
+		{
+			Name:           "ten",
+			SelectedOption: "10",
+			ExpectedScore:  10,
+		},
+		{
+			Name:           "too low",
+			SelectedOption: "-400",
+			ExpectError:    true,
+		},
+		{
+			Name:           "too high",
+			SelectedOption: "1000000",
+			ExpectError:    true,
+		},
+		{
+			Name:           "garbage",
+			SelectedOption: "garbage",
+			ExpectError:    true,
+		},
+		{
+			Name:           "empty",
+			SelectedOption: "",
+			ExpectError:    true,
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			score, err := getScore(test.SelectedOption)
+
+			assert.Equal(t, test.ExpectedScore, score)
+			if test.ExpectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestRequiresUserId(t *testing.T) {
+	t.Run("should call handler when user ID is present", func(t *testing.T) {
+		called := false
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		request.Header.Set("Mattermost-User-ID", "1234ab")
+
+		requiresUserId(handler)(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+		assert.True(t, called)
+	})
+
+	t.Run("should return HTTP 401 when user ID is missing", func(t *testing.T) {
+		called := false
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		requiresUserId(handler)(recorder, request)
+
+		assert.Equal(t, http.StatusUnauthorized, recorder.Result().StatusCode)
+		assert.False(t, called)
+	})
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -85,7 +86,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	if p.isActivated() {
 		if configuration.EnableSurvey && !oldConfiguration.EnableSurvey {
 			// Check if a survey needs to be sent when the survey is enabled
-			go p.checkForNextSurvey(p.getServerVersion())
+			go p.checkForNextSurvey(time.Now().UTC())
 		}
 	}
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -85,7 +85,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	if p.isActivated() {
 		if configuration.EnableSurvey && !oldConfiguration.EnableSurvey {
 			// Check if a survey needs to be sent when the survey is enabled
-			go p.checkForNextSurvey(p.serverVersion)
+			go p.checkForNextSurvey(p.getServerVersion())
 		}
 	}
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"reflect"
-	"time"
 
 	"github.com/pkg/errors"
 )
@@ -83,12 +82,14 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	p.setConfiguration(configuration)
 
-	if p.isActivated() {
-		if configuration.EnableSurvey && !oldConfiguration.EnableSurvey {
-			// Check if a survey needs to be sent when the survey is enabled
-			go p.checkForNextSurvey(time.Now().UTC())
-		}
+	if p.hasSurveyBeenEnabled(configuration, oldConfiguration) {
+		// Check if a survey needs to be sent when the survey is enabled
+		go p.checkForNextSurvey(p.now().UTC())
 	}
 
 	return nil
+}
+
+func (p *Plugin) hasSurveyBeenEnabled(new *configuration, old *configuration) bool {
+	return p.isActivated() && (new.EnableSurvey && !old.EnableSurvey)
 }

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasSurveyBeenEnabled(t *testing.T) {
+	for _, test := range []struct {
+		Name            string
+		Activated       bool
+		NewEnableSurvey bool
+		OldEnableSurvey bool
+		Expected        bool
+	}{
+		{
+			Name:            "survey has been enabled",
+			Activated:       true,
+			NewEnableSurvey: true,
+			OldEnableSurvey: false,
+			Expected:        true,
+		},
+		{
+			Name:            "survey has been enabled, but plugin has not been activated yet",
+			Activated:       false,
+			NewEnableSurvey: true,
+			OldEnableSurvey: false,
+			Expected:        false,
+		},
+		{
+			Name:            "survey was already enabled",
+			Activated:       true,
+			NewEnableSurvey: true,
+			OldEnableSurvey: true,
+			Expected:        false,
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			p := &Plugin{
+				activated: test.Activated,
+			}
+
+			new := &configuration{EnableSurvey: test.NewEnableSurvey}
+			old := &configuration{EnableSurvey: test.OldEnableSurvey}
+
+			assert.Equal(t, test.Expected, p.hasSurveyBeenEnabled(new, old))
+		})
+	}
+}

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -23,18 +23,30 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
+	// Make sure that Surveybot doesn't respond to itself
 	if post.UserId == p.botUserID {
 		return
 	}
 
-	// Respond to any written feedback that the bot receives
+	// Make sure this is a post sent directly to Surveybot
 	channel, err := p.API.GetChannel(post.ChannelId)
 	if err != nil {
-		p.API.LogWarn("Unable to get channel for post to send Surveybot response", "err", err)
+		p.API.LogError("Unable to get channel for Surveybot feedback", "err", err)
 		return
 	}
 
 	if !p.IsBotDMChannel(channel) {
+		return
+	}
+
+	// Make sure this is not a post sent by another bot
+	user, err := p.API.GetUser(post.UserId)
+	if err != nil {
+		p.API.LogError("Unable to get sender for Surveybot feedback", "err", err)
+		return
+	}
+
+	if user.IsBot {
 		return
 	}
 

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -7,7 +7,7 @@ import (
 
 func (p *Plugin) ChannelHasBeenCreated(c *plugin.Context, channel *model.Channel) {
 	// Set the description for any DM channels opened between Surveybot and a user
-	if !p.isBotDMChannel(channel) {
+	if !p.IsBotDMChannel(channel) {
 		return
 	}
 
@@ -23,7 +23,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	if post.UserId == p.botUserId {
+	if post.UserId == p.botUserID {
 		return
 	}
 
@@ -34,7 +34,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	if !p.isBotDMChannel(channel) {
+	if !p.IsBotDMChannel(channel) {
 		return
 	}
 

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -29,9 +29,9 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 	}
 
 	// Make sure this is a post sent directly to Surveybot
-	channel, err := p.API.GetChannel(post.ChannelId)
-	if err != nil {
-		p.API.LogError("Unable to get channel for Surveybot feedback", "err", err)
+	channel, appErr := p.API.GetChannel(post.ChannelId)
+	if appErr != nil {
+		p.API.LogError("Unable to get channel for Surveybot feedback", "err", appErr)
 		return
 	}
 
@@ -40,9 +40,9 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 	}
 
 	// Make sure this is not a post sent by another bot
-	user, err := p.API.GetUser(post.UserId)
-	if err != nil {
-		p.API.LogError("Unable to get sender for Surveybot feedback", "err", err)
+	user, appErr := p.API.GetUser(post.UserId)
+	if appErr != nil {
+		p.API.LogError("Unable to get sender for Surveybot feedback", "err", appErr)
 		return
 	}
 
@@ -51,14 +51,18 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 	}
 
 	// Send the feedback to Segment
-	p.sendFeedback(post.Message, post.UserId, post.CreateAt)
+	if err := p.sendFeedback(post.Message, post.UserId, post.CreateAt); err != nil {
+		p.API.LogError("Failed to send Surveybot feedback to Segment", "err", err.Error())
+
+		// Still appear to the end user as if their feedback was actually sent
+	}
 
 	// Respond to the feedback
-	_, err = p.CreateBotDMPost(post.UserId, &model.Post{
+	_, appErr = p.CreateBotDMPost(post.UserId, &model.Post{
 		Message: feedbackResponseBody,
 		Type:    "custom_nps_thanks",
 	})
-	if err != nil {
+	if appErr != nil {
 		p.API.LogError("Failed to respond to Surveybot feedback")
 	}
 }

--- a/server/hooks_test.go
+++ b/server/hooks_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestChannelHasBeenCreated(t *testing.T) {
+	botUserID := model.NewId()
+
+	t.Run("should set channel header for a Surveybot DM channel", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("UpdateChannel", mock.MatchedBy(func(channel *model.Channel) bool {
+			return channel.Header == SURVEYBOT_DESCRIPTION
+		})).Return(nil, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			botUserID: botUserID,
+		}
+		p.SetAPI(api)
+
+		p.ChannelHasBeenCreated(nil, &model.Channel{
+			Type: model.CHANNEL_DIRECT,
+			Name: fmt.Sprintf("%s__%s", botUserID, model.NewId()),
+		})
+	})
+
+	t.Run("should do nothing for other channels", func(t *testing.T) {
+		p := &Plugin{}
+
+		p.ChannelHasBeenCreated(nil, &model.Channel{
+			Type: model.CHANNEL_OPEN,
+		})
+	})
+}
+
+func TestMessageHasBeenPosted(t *testing.T) {
+	botChannelID := model.NewId()
+	botUserID := model.NewId()
+	userID := model.NewId()
+
+	t.Run("should send feedback to segment and respond to user", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		api.On("GetChannel", botChannelID).Return(&model.Channel{
+			Type: model.CHANNEL_DIRECT,
+			Name: fmt.Sprintf("%s__%s", botUserID, userID),
+		}, nil)
+		api.On("GetUser", userID).Return(&model.User{}, nil)
+		api.On("GetDirectChannel", userID, botUserID).Return(&model.Channel{
+			Id: botChannelID,
+		}, nil)
+		api.On("CreatePost", mock.Anything).Return(&model.Post{}, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			blockSegmentEvents: true,
+			botUserID:          botUserID,
+		}
+		p.SetAPI(api)
+
+		p.MessageHasBeenPosted(nil, &model.Post{
+			ChannelId: botChannelID,
+			UserId:    userID,
+		})
+	})
+
+	t.Run("should not respond to posts made by other bots", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		api.On("GetChannel", botChannelID).Return(&model.Channel{
+			Type: model.CHANNEL_DIRECT,
+			Name: fmt.Sprintf("%s__%s", botUserID, userID),
+		}, nil)
+		api.On("GetUser", userID).Return(&model.User{
+			IsBot: true,
+		}, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			blockSegmentEvents: true,
+			botUserID:          botUserID,
+		}
+		p.SetAPI(api)
+
+		p.MessageHasBeenPosted(nil, &model.Post{
+			ChannelId: botChannelID,
+			UserId:    userID,
+		})
+	})
+
+	t.Run("should not respond to a post outside of a Surveybot DM channel", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		api.On("GetChannel", botChannelID).Return(&model.Channel{
+			Type: model.CHANNEL_OPEN,
+		}, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			blockSegmentEvents: true,
+			botUserID:          botUserID,
+		}
+		p.SetAPI(api)
+
+		p.MessageHasBeenPosted(nil, &model.Post{
+			ChannelId: botChannelID,
+			UserId:    userID,
+		})
+	})
+
+	t.Run("should not respond to posts made by Surveybot", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(true),
+			},
+		})
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			blockSegmentEvents: true,
+			botUserID:          botUserID,
+		}
+		p.SetAPI(api)
+
+		p.MessageHasBeenPosted(nil, &model.Post{
+			ChannelId: botChannelID,
+			UserId:    botUserID,
+		})
+	})
+
+	t.Run("should do nothing if diagnostics are disabled", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("GetConfig").Return(&model.Config{
+			LogSettings: model.LogSettings{
+				EnableDiagnostics: model.NewBool(false),
+			},
+		})
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{
+			blockSegmentEvents: true,
+			botUserID:          botUserID,
+		}
+		p.SetAPI(api)
+
+		p.MessageHasBeenPosted(nil, &model.Post{
+			ChannelId: botChannelID,
+			UserId:    userID,
+		})
+	})
+}
+
+func TestUserHasLoggedIn(t *testing.T) {
+	t.Run("should check for DMs when a user logs in", func(t *testing.T) {
+		t.SkipNow()
+	})
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -10,9 +10,26 @@ import (
 )
 
 const (
-	ADMIN_DM_NOTICE_KEY = "AdminDM-"
-	SERVER_UPGRADE_KEY  = "ServerUpgrade"
-	USER_SURVEY_KEY     = "UserSurvey-"
+	// ADMIN_DM_NOTICE_KEY is used to store whether or not a DM notifying an admin about a scheduled survey has been
+	// sent. It should contain the user's ID and server version like "AdminDM-abc123-5.10.0".
+	ADMIN_DM_NOTICE_KEY = "AdminDM-%s-%s"
+
+	// LAST_ADMIN_NOTICE_KEY is used to store the last time.Time that notifications were sent to admins to inform them
+	// of an upcoming NPS survey.
+	LAST_ADMIN_NOTICE_KEY = "LastAdminNotice"
+
+	// SERVER_UPGRADE_KEY is used to store a serverUpgrade object containing when an upgrade to a given version first
+	// occurred. It should contain the server version like "ServerUpgrade-5.10.0".
+	SERVER_UPGRADE_KEY = "ServerUpgrade-%s"
+
+	// SURVEY_KEY is used to store the surveyState containing when an NPS survey starts and ends on a given version
+	// of Mattermost. It should contain the server version like "Survey-5.10.0".
+	SURVEY_KEY = "Survey-%s"
+
+	// USER_SURVEY_KEY is used to store the userSurveyState tracking a user's progress through an NPS survey on the
+	// given version of Mattermost. It should contain the user's ID and server version like
+	// "UserSurvey-abc123-5.10.0".
+	USER_SURVEY_KEY = "UserSurvey-%s-%s"
 
 	SURVEYBOT_DESCRIPTION = "Surveybot collects user feedback to improve Mattermost. [Learn more](https://mattermost.com/pl/default-nps)."
 
@@ -40,7 +57,7 @@ type Plugin struct {
 	// prevent users from receiving duplicate Surveybot DMs.
 	connectedLock sync.Mutex
 
-	botUserId string
+	botUserID string
 
 	client *analytics.Client
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -46,6 +46,9 @@ type Plugin struct {
 	// setConfiguration for usage.
 	configuration *configuration
 
+	// serverVersion is the current major/minor server version without the patch version included.
+	serverVersion string
+
 	// activated is used to track whether or not OnActivate has initialized the plugin state.
 	activated bool
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -71,6 +71,12 @@ type Plugin struct {
 	// NPS survey.
 	userSurveyMaxDelay time.Duration
 
+	// blockSegmentEvents prevents the plugin from sending events to Segment during testing.
+	blockSegmentEvents bool
+
+	// now provides access to time.Now in a way that is mockable for unit testing.
+	now func() time.Time
+
 	// readFile provides access to ioutil.ReadFile in a way that is mockable for unit testing.
 	readFile func(path string) ([]byte, error)
 }
@@ -80,6 +86,7 @@ func NewPlugin() *Plugin {
 		upgradeCheckMaxDelay: DEFAULT_UPGRADE_CHECK_MAX_DELAY,
 		userSurveyMaxDelay:   DEAFULT_USER_SURVEY_MAX_DELAY,
 
+		now:      time.Now,
 		readFile: ioutil.ReadFile,
 	}
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/mattermost/mattermost-server/plugin"
 	analytics "github.com/segmentio/analytics-go"
 )
@@ -40,8 +39,6 @@ type Plugin struct {
 	// connectedLock is used to prevent multiple connected requests from being handled at the same time in order to
 	// prevent users from receiving duplicate Surveybot DMs.
 	connectedLock sync.Mutex
-
-	serverVersion semver.Version
 
 	botUserId string
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -27,9 +27,8 @@ const (
 	SURVEY_KEY = "Survey-%s"
 
 	// USER_SURVEY_KEY is used to store the userSurveyState tracking a user's progress through an NPS survey on the
-	// given version of Mattermost. It should contain the user's ID and server version like
-	// "UserSurvey-abc123-5.10.0".
-	USER_SURVEY_KEY = "UserSurvey-%s-%s"
+	// given version of Mattermost. It should contain the user's ID like "UserSurvey-abc123".
+	USER_SURVEY_KEY = "UserSurvey-%s"
 
 	SURVEYBOT_DESCRIPTION = "Surveybot collects user feedback to improve Mattermost. [Learn more](https://mattermost.com/pl/default-nps)."
 

--- a/server/segment_test.go
+++ b/server/segment_test.go
@@ -9,15 +9,15 @@ import (
 )
 
 func TestGetEventProperties(t *testing.T) {
-	userId := model.NewId()
+	userID := model.NewId()
 	userCreateAt := int64(1546304461000)
 	timestamp := int64(1552331717000)
 
 	serverVersion := "5.10.0"
 	systemInstallDate := int64(1497898133094)
-	diagnosticId := model.NewId()
+	diagnosticID := model.NewId()
 
-	licenseId := model.NewId()
+	licenseID := model.NewId()
 	skuShortName := model.NewId()
 
 	for _, test := range []struct {
@@ -33,28 +33,28 @@ func TestGetEventProperties(t *testing.T) {
 
 				api.On("GetSystemInstallDate").Return(systemInstallDate, nil)
 
-				api.On("GetUser", userId).Return(&model.User{
-					Id:       userId,
+				api.On("GetUser", userID).Return(&model.User{
+					Id:       userID,
 					CreateAt: userCreateAt,
 					Roles:    "system_user",
 				}, nil)
 
 				api.On("GetLicense").Return(&model.License{
-					Id:           licenseId,
+					Id:           licenseID,
 					SkuShortName: skuShortName,
 				})
 
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userId,
+				"user_id":             userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
-				"server_id":           diagnosticId,
+				"server_id":           diagnosticID,
 				"user_role":           "user",
 				"user_create_at":      userCreateAt,
-				"license_id":          licenseId,
+				"license_id":          licenseID,
 				"license_sku":         skuShortName,
 			},
 		},
@@ -65,28 +65,28 @@ func TestGetEventProperties(t *testing.T) {
 
 				api.On("GetSystemInstallDate").Return(int64(0), &model.AppError{})
 
-				api.On("GetUser", userId).Return(&model.User{
-					Id:       userId,
+				api.On("GetUser", userID).Return(&model.User{
+					Id:       userID,
 					CreateAt: userCreateAt,
 					Roles:    "system_user",
 				}, nil)
 
 				api.On("GetLicense").Return(&model.License{
-					Id:           licenseId,
+					Id:           licenseID,
 					SkuShortName: skuShortName,
 				})
 
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userId,
+				"user_id":             userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": int64(0),
-				"server_id":           diagnosticId,
+				"server_id":           diagnosticID,
 				"user_role":           "user",
 				"user_create_at":      userCreateAt,
-				"license_id":          licenseId,
+				"license_id":          licenseID,
 				"license_sku":         skuShortName,
 			},
 		},
@@ -95,26 +95,26 @@ func TestGetEventProperties(t *testing.T) {
 			SetupAPI: func() *plugintest.API {
 				api := &plugintest.API{}
 
-				api.On("GetUser", userId).Return(nil, &model.AppError{})
+				api.On("GetUser", userID).Return(nil, &model.AppError{})
 
 				api.On("GetSystemInstallDate").Return(systemInstallDate, nil)
 
 				api.On("GetLicense").Return(&model.License{
-					Id:           licenseId,
+					Id:           licenseID,
 					SkuShortName: skuShortName,
 				})
 
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userId,
+				"user_id":             userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
-				"server_id":           diagnosticId,
+				"server_id":           diagnosticID,
 				"user_role":           "",
 				"user_create_at":      int64(0),
-				"license_id":          licenseId,
+				"license_id":          licenseID,
 				"license_sku":         skuShortName,
 			},
 		},
@@ -123,8 +123,8 @@ func TestGetEventProperties(t *testing.T) {
 			SetupAPI: func() *plugintest.API {
 				api := &plugintest.API{}
 
-				api.On("GetUser", userId).Return(&model.User{
-					Id:       userId,
+				api.On("GetUser", userID).Return(&model.User{
+					Id:       userID,
 					CreateAt: userCreateAt,
 					Roles:    "system_user",
 				}, nil)
@@ -136,11 +136,11 @@ func TestGetEventProperties(t *testing.T) {
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userId,
+				"user_id":             userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
-				"server_id":           diagnosticId,
+				"server_id":           diagnosticID,
 				"user_role":           "user",
 				"user_create_at":      userCreateAt,
 				"license_id":          "",
@@ -154,14 +154,14 @@ func TestGetEventProperties(t *testing.T) {
 
 				api.On("GetSystemInstallDate").Return(systemInstallDate, nil)
 
-				api.On("GetUser", userId).Return(&model.User{
-					Id:       userId,
+				api.On("GetUser", userID).Return(&model.User{
+					Id:       userID,
 					CreateAt: userCreateAt,
 					Roles:    "system_user",
 				}, nil)
 
 				api.On("GetLicense").Return(&model.License{
-					Id:           licenseId,
+					Id:           licenseID,
 					SkuShortName: skuShortName,
 				})
 
@@ -172,14 +172,14 @@ func TestGetEventProperties(t *testing.T) {
 				"other_2": "abcd",
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userId,
+				"user_id":             userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
-				"server_id":           diagnosticId,
+				"server_id":           diagnosticID,
 				"user_role":           "user",
 				"user_create_at":      userCreateAt,
-				"license_id":          licenseId,
+				"license_id":          licenseID,
 				"license_sku":         skuShortName,
 				"other_1":             1234,
 				"other_2":             "abcd",
@@ -191,14 +191,14 @@ func TestGetEventProperties(t *testing.T) {
 			defer api.AssertExpectations(t)
 
 			api.On("GetServerVersion").Return("5.10.0")
-			api.On("GetDiagnosticId").Return(diagnosticId)
+			api.On("GetDiagnosticId").Return(diagnosticID)
 
-			api.On("GetTeamMembersForUser", userId, 0, 50).Return([]*model.TeamMember{}, nil).Maybe()
+			api.On("GetTeamMembersForUser", userID, 0, 50).Return([]*model.TeamMember{}, nil).Maybe()
 
 			p := Plugin{}
 			p.SetAPI(api)
 
-			assert.Equal(t, test.Expected, p.getEventProperties(userId, timestamp, test.OtherProperties))
+			assert.Equal(t, test.Expected, p.getEventProperties(userID, timestamp, test.OtherProperties))
 		})
 	}
 }

--- a/server/survey.go
+++ b/server/survey.go
@@ -69,7 +69,7 @@ func (p *Plugin) checkForNextSurvey(now time.Time) bool {
 	}
 
 	var nextSurvey *surveyState
-	if err := p.KVGet(fmt.Sprintf(SURVEY_KEY, nextSurvey.ServerVersion), nextSurvey); err != nil {
+	if err := p.KVGet(fmt.Sprintf(SURVEY_KEY, p.serverVersion), &nextSurvey); err != nil {
 		p.API.LogError("Failed to get survey state", "err", err)
 		return false
 	}
@@ -106,7 +106,7 @@ func (p *Plugin) checkForNextSurvey(now time.Time) bool {
 
 func (p *Plugin) sendAdminNotices(now time.Time, nextSurvey *surveyState) (bool, error) {
 	var lastSentAt *time.Time
-	if err := p.KVGet(LAST_ADMIN_NOTICE_KEY, lastSentAt); err != nil {
+	if err := p.KVGet(LAST_ADMIN_NOTICE_KEY, &lastSentAt); err != nil {
 		return false, err
 	}
 

--- a/server/survey.go
+++ b/server/survey.go
@@ -254,7 +254,7 @@ type surveyState struct {
 	ScorePostId   string
 }
 
-func (p *Plugin) shouldSendSurveyDM(user *model.User, now time.Time) bool {
+func (p *Plugin) shouldSendSurveyDM(user *model.User, serverVersion semver.Version, now time.Time) bool {
 	if !p.getConfiguration().EnableSurvey {
 		// Surveys are disabled
 		return false
@@ -288,7 +288,7 @@ func (p *Plugin) shouldSendSurveyDM(user *model.User, now time.Time) bool {
 		return true
 	}
 
-	if state.ServerVersion.Major == p.serverVersion.Major && state.ServerVersion.Minor == p.serverVersion.Minor {
+	if state.ServerVersion.Major == serverVersion.Major && state.ServerVersion.Minor == serverVersion.Minor {
 		// Last survey occurred on the current version
 		return false
 	}
@@ -318,7 +318,7 @@ func (p *Plugin) sendSurveyDM(user *model.User, now time.Time) {
 
 	// Store that the survey has been sent
 	err = p.KVSet(USER_SURVEY_KEY+user.Id, &surveyState{
-		ServerVersion: p.serverVersion,
+		ServerVersion: p.getServerVersion(),
 		SentAt:        now,
 		ScorePostId:   post.Id,
 	})

--- a/server/survey_test.go
+++ b/server/survey_test.go
@@ -697,11 +697,10 @@ func TestShouldSendSurveyDM(t *testing.T) {
 				configuration: &configuration{
 					EnableSurvey: test.EnableSurvey,
 				},
-				serverVersion: test.ServerVersion,
 			}
 			p.SetAPI(api)
 
-			result := p.shouldSendSurveyDM(test.User, test.Now)
+			result := p.shouldSendSurveyDM(test.User, test.ServerVersion, test.Now)
 
 			assert.Equal(t, test.Expected, result)
 		})
@@ -711,7 +710,6 @@ func TestShouldSendSurveyDM(t *testing.T) {
 func TestSendSurveyDM(t *testing.T) {
 	t.Run("should send DM and mark survey as sent", func(t *testing.T) {
 		botUserId := model.NewId()
-		serverVersion := semver.MustParse("5.10.0")
 		user := &model.User{
 			Id:       model.NewId(),
 			Username: "testuser",
@@ -728,6 +726,7 @@ func TestSendSurveyDM(t *testing.T) {
 		})
 		api.On("GetDirectChannel", user.Id, botUserId).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
+		api.On("GetServerVersion").Return("5.10.0")
 		api.On("KVSet", USER_SURVEY_KEY+user.Id, mustMarshalJSON(&surveyState{
 			ServerVersion: semver.MustParse("5.10.0"),
 			SentAt:        toDate(2019, 03, 01),
@@ -736,8 +735,7 @@ func TestSendSurveyDM(t *testing.T) {
 		defer api.AssertExpectations(t)
 
 		p := Plugin{
-			botUserId:     botUserId,
-			serverVersion: serverVersion,
+			botUserId: botUserId,
 		}
 		p.SetAPI(api)
 
@@ -746,7 +744,6 @@ func TestSendSurveyDM(t *testing.T) {
 
 	t.Run("should log error from failed DM", func(t *testing.T) {
 		botUserId := model.NewId()
-		serverVersion := semver.MustParse("5.10.0")
 		user := &model.User{
 			Id:       model.NewId(),
 			Username: "testuser",
@@ -769,8 +766,7 @@ func TestSendSurveyDM(t *testing.T) {
 		defer api.AssertExpectations(t)
 
 		p := Plugin{
-			botUserId:     botUserId,
-			serverVersion: serverVersion,
+			botUserId: botUserId,
 		}
 		p.SetAPI(api)
 
@@ -779,7 +775,6 @@ func TestSendSurveyDM(t *testing.T) {
 
 	t.Run("should log error when failing to store sent survey", func(t *testing.T) {
 		botUserId := model.NewId()
-		serverVersion := semver.MustParse("5.10.0")
 		user := &model.User{
 			Id:       model.NewId(),
 			Username: "testuser",
@@ -798,6 +793,7 @@ func TestSendSurveyDM(t *testing.T) {
 		})
 		api.On("GetDirectChannel", user.Id, botUserId).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
+		api.On("GetServerVersion").Return("5.10.0")
 		api.On("KVSet", USER_SURVEY_KEY+user.Id, mustMarshalJSON(&surveyState{
 			ServerVersion: semver.MustParse("5.10.0"),
 			SentAt:        toDate(2019, 3, 1),
@@ -807,8 +803,7 @@ func TestSendSurveyDM(t *testing.T) {
 		defer api.AssertExpectations(t)
 
 		p := Plugin{
-			botUserId:     botUserId,
-			serverVersion: serverVersion,
+			botUserId: botUserId,
 		}
 		p.SetAPI(api)
 

--- a/server/survey_test.go
+++ b/server/survey_test.go
@@ -406,13 +406,11 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(nil, nil)
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, nil)
 		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion), newSurveyStateBytes).Return(nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest"), newSurveyStateBytes).Return(nil)
+		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id), newSurveyStateBytes).Return(nil)
 		defer api.AssertExpectations(t)
 
 		p := &Plugin{
@@ -429,40 +427,6 @@ func TestCheckForSurveyDM(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("should return error if unable to save latest survey state", func(t *testing.T) {
-		user := &model.User{
-			Id:       model.NewId(),
-			CreateAt: now.Add(-1*TIME_UNTIL_SURVEY).UnixNano() / int64(time.Millisecond),
-		}
-
-		api := makeAPIMock()
-		api.On("KVGet", fmt.Sprintf(SURVEY_KEY, serverVersion)).Return(mustMarshalJSON(&surveyState{
-			ServerVersion: serverVersion,
-			StartAt:       now,
-		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(nil, nil)
-		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
-		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
-		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion), newSurveyStateBytes).Return(nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest"), newSurveyStateBytes).Return(&model.AppError{})
-		defer api.AssertExpectations(t)
-
-		p := &Plugin{
-			botUserID: botUserID,
-			configuration: &configuration{
-				EnableSurvey: true,
-			},
-		}
-		p.SetAPI(api)
-
-		sent, err := p.checkForSurveyDM(user, serverVersion, now)
-
-		assert.True(t, sent)
-		assert.NotNil(t, err)
-	})
-
 	t.Run("should return error if unable to save survey state", func(t *testing.T) {
 		user := &model.User{
 			Id:       model.NewId(),
@@ -474,12 +438,11 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(nil, nil)
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, nil)
 		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion), newSurveyStateBytes).Return(&model.AppError{})
+		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id), newSurveyStateBytes).Return(&model.AppError{})
 		defer api.AssertExpectations(t)
 
 		p := &Plugin{
@@ -507,8 +470,7 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(nil, nil)
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, nil)
 		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(nil, &model.AppError{})
@@ -539,8 +501,7 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(mustMarshalJSON(&userSurveyState{
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(mustMarshalJSON(&userSurveyState{
 			ServerVersion: semver.MustParse("5.11.0"),
 			SentAt:        now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS),
 			AnsweredAt:    now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS),
@@ -548,8 +509,7 @@ func TestCheckForSurveyDM(t *testing.T) {
 		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion), newSurveyStateBytes).Return(nil)
-		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest"), newSurveyStateBytes).Return(nil)
+		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id), newSurveyStateBytes).Return(nil)
 		defer api.AssertExpectations(t)
 
 		p := &Plugin{
@@ -577,8 +537,7 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(mustMarshalJSON(&userSurveyState{
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(mustMarshalJSON(&userSurveyState{
 			ServerVersion: semver.MustParse("5.11.0"),
 			SentAt:        now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS),
 			AnsweredAt:    now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS).Add(time.Millisecond),
@@ -610,8 +569,7 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, "latest")).Return(mustMarshalJSON(&userSurveyState{
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(mustMarshalJSON(&userSurveyState{
 			ServerVersion: semver.MustParse("5.11.0"),
 			SentAt:        now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS).Add(time.Millisecond),
 		}), nil)
@@ -642,7 +600,9 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(mustMarshalJSON(&userSurveyState{}), nil)
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(mustMarshalJSON(&userSurveyState{
+			ServerVersion: serverVersion,
+		}), nil)
 		defer api.AssertExpectations(t)
 
 		p := &Plugin{
@@ -670,7 +630,7 @@ func TestCheckForSurveyDM(t *testing.T) {
 			ServerVersion: serverVersion,
 			StartAt:       now,
 		}), nil)
-		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id, serverVersion)).Return(nil, &model.AppError{})
+		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, &model.AppError{})
 		defer api.AssertExpectations(t)
 
 		p := &Plugin{
@@ -815,11 +775,11 @@ func TestMarkSurveyAnswered(t *testing.T) {
 	userID := model.NewId()
 
 	api := &plugintest.API{}
-	api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, userID, serverVersion)).Return(mustMarshalJSON(&userSurveyState{
+	api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, userID)).Return(mustMarshalJSON(&userSurveyState{
 		ServerVersion: serverVersion,
 		SentAt:        toDate(2019, 3, 1),
 	}), nil)
-	api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, userID, serverVersion), mustMarshalJSON(&userSurveyState{
+	api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, userID), mustMarshalJSON(&userSurveyState{
 		ServerVersion: serverVersion,
 		SentAt:        toDate(2019, 3, 1),
 		AnsweredAt:    now,
@@ -829,7 +789,7 @@ func TestMarkSurveyAnswered(t *testing.T) {
 	p := Plugin{}
 	p.SetAPI(api)
 
-	err := p.markSurveyAnswered(userID, serverVersion, now)
+	err := p.markSurveyAnswered(userID, now)
 
 	assert.Nil(t, err)
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -75,8 +75,8 @@ func (p *Plugin) IsBotDMChannel(channel *model.Channel) bool {
 }
 
 func (p *Plugin) sleepUpTo(maxDelay time.Duration) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	delay := time.Duration(r.Int63n(int64(maxDelay)))
+	r := rand.New(rand.NewSource(p.now().UnixNano()))
+	delay := time.Duration(r.Int63n(int64(maxDelay) + 1))
 
 	time.Sleep(delay)
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,27 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func (p *Plugin) GetServerVersion() (semver.Version, *model.AppError) {
-	versionString := p.API.GetServerVersion()
-
-	version, err := semver.Parse(versionString)
-	if err != nil {
-		return version, &model.AppError{Message: err.Error()}
-	}
-
-	// Remove the parts of the version that the NPS plugin doesn't care about
-	version.Patch = 0
-	version.Pre = nil
-	version.Build = nil
-
-	return version, nil
+// getServerVersion returns the current server version with only the major and minor version set. For example, both
+// 5.10.0 and 5.10.1 will be returned as "5.10.0" by this method.
+func getServerVersion(serverVersion string) string {
+	return regexp.MustCompile(`\.[1-9]\d*$`).ReplaceAllString(serverVersion, ".0")
 }
 
 func (p *Plugin) KVGet(key string, v interface{}) *model.AppError {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -241,11 +241,13 @@ func mustMarshalJSON(v interface{}) []byte {
 	return data
 }
 
-func mustUnmarshalJSON(data []byte, v interface{}) {
+func mustUnmarshalJSON(data []byte, v interface{}) interface{} {
 	err := json.Unmarshal(data, v)
 	if err != nil {
 		panic(err)
 	}
+
+	return v
 }
 
 func toDate(year int, month time.Month, day int) time.Time {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+)
+
+func TestGetServerVersion(t *testing.T) {
+	t.Run("should return the correct version", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetServerVersion").Return("5.10.0")
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		version, err := p.GetServerVersion()
+
+		assert.Equal(t, semver.MustParse("5.10.0"), version)
+		assert.Nil(t, err)
+	})
+
+	t.Run("should not return the patch number or pre-release version", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetServerVersion").Return("5.11.1-rc1")
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		version, err := p.GetServerVersion()
+
+		assert.Equal(t, semver.MustParse("5.11.0"), version)
+		assert.Nil(t, err)
+	})
+
+	t.Run("should return an error if the version cannot be paresed", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetServerVersion").Return("garbage")
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		version, err := p.GetServerVersion()
+
+		assert.Equal(t, semver.Version{}, version)
+		assert.NotNil(t, err)
+	})
+}
+
+func TestKVSet(t *testing.T) {
+	t.Run("should save a json encoded object in the KV store", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("KVSet", "key", []byte(`"value"`)).Return(nil)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		err := p.KVSet("key", "value")
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("should return an error if saving the value in the KV store fails", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("KVSet", "key", mock.Anything).Return(&model.AppError{})
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		err := p.KVSet("key", "value")
+
+		assert.NotNil(t, err)
+	})
+}
+
+func TestKVGet(t *testing.T) {
+	t.Run("should save a json encoded object in the KV store", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("KVGet", "key").Return([]byte(`"value"`), nil)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		var value string
+		err := p.KVGet("key", &value)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "value", value)
+	})
+
+	t.Run("should not modify value and return nil when an object doesn't exist in the KV store", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("KVGet", "key").Return(nil, nil)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		var value string
+		err := p.KVGet("key", &value)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "", value)
+	})
+
+	t.Run("should return an error if getting the value from the KV store fails", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("KVGet", "key").Return(nil, &model.AppError{})
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		var value string
+		err := p.KVGet("key", &value)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "", value)
+	})
+
+	t.Run("should return an error if decoding the value fails", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("KVGet", "key").Return([]byte(`"value`), nil)
+
+		p := Plugin{}
+		p.SetAPI(api)
+
+		var value string
+		err := p.KVGet("key", &value)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "", value)
+	})
+}
+
+func TestCreateBotDMPost(t *testing.T) {
+	t.Run("should send bot DM correctly", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetDirectChannel", "userID", "botUserID").Return(&model.Channel{Id: "channelID"}, nil)
+		api.On("CreatePost", &model.Post{
+			ChannelId: "channelID",
+			Message:   "test",
+			UserId:    "botUserID",
+		}).Return(&model.Post{
+			Id:        "postID",
+			ChannelId: "channelID",
+			Message:   "test",
+			UserId:    "botUserID",
+		}, nil)
+
+		p := Plugin{
+			botUserID: "botUserID",
+		}
+		p.SetAPI(api)
+
+		post, err := p.CreateBotDMPost("userID", &model.Post{
+			Message: "test",
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, "botUserID", post.UserId)
+		assert.Equal(t, "channelID", post.ChannelId)
+	})
+
+	t.Run("should return an error if unable to get the DM channel", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetDirectChannel", "userID", "botUserID").Return(nil, &model.AppError{})
+
+		p := Plugin{
+			botUserID: "botUserID",
+		}
+		p.SetAPI(api)
+
+		_, err := p.CreateBotDMPost("userID", &model.Post{
+			Message: "test",
+		})
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("should return an error if unable to create the post", func(t *testing.T) {
+		api := makeAPIMock()
+		api.On("GetDirectChannel", "userID", "botUserID").Return(&model.Channel{Id: "channelID"}, nil)
+		api.On("CreatePost", mock.Anything).Return(nil, &model.AppError{})
+
+		p := Plugin{
+			botUserID: "botUserID",
+		}
+		p.SetAPI(api)
+
+		_, err := p.CreateBotDMPost("userID", &model.Post{
+			Message: "test",
+		})
+
+		assert.NotNil(t, err)
+	})
+}
+
+func TestIsBotChannel(t *testing.T) {
+	for _, test := range []struct {
+		Name     string
+		Channel  *model.Channel
+		Expected bool
+	}{
+		{
+			Name:     "not a direct channel",
+			Channel:  &model.Channel{Type: model.CHANNEL_OPEN},
+			Expected: false,
+		},
+		{
+			Name: "a direct channel with another user",
+			Channel: &model.Channel{
+				Name: "user1__user2",
+				Type: model.CHANNEL_DIRECT,
+			},
+			Expected: false,
+		},
+		{
+			Name: "a direct channel with the name containing the bot's ID first",
+			Channel: &model.Channel{
+				Name: "botUserID__user2",
+				Type: model.CHANNEL_DIRECT,
+			},
+			Expected: true,
+		},
+		{
+			Name: "a direct channel with the name containing the bot's ID second",
+			Channel: &model.Channel{
+				Name: "user1__botUserID",
+				Type: model.CHANNEL_DIRECT,
+			},
+			Expected: true,
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			p := Plugin{
+				botUserID: "botUserID",
+			}
+
+			assert.Equal(t, test.Expected, p.IsBotDMChannel(test.Channel))
+		})
+	}
+}
+
+// Test helper functions
+
+func makeAPIMock() *plugintest.API {
+	api := &plugintest.API{}
+
+	api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	api.On("LogWarn", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	api.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	return api
+}
+
+func mustMarshalJSON(v interface{}) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+func mustUnmarshalJSON(data []byte, v interface{}) {
+	err := json.Unmarshal(data, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func toDate(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}


### PR DESCRIPTION
This does a lot of refactoring and some cleanup while adding a lot of unit tests.

Major changes:
- I split the KV store entries that track when an upgrade occurred from when a survey is scheduled so that it's easier to reason about how the code should work. The previous version gave me a lot of problems because I kept making mistakes when I was trying to write utilities to help QA test the plugin.
- I added a lot of unit tests to everything. The tests aren't amazing because of limitations of the mocking framework (everything has to be mocked by hand), but refactoring some of the logic into helper functions has helped that somewhat.

Minor changes:
- I renamed everything like `userId` to `userID` for consistency
- I removed the dependency on `github.com/blang/semver` because we weren't really making use of its features, and it made working with the version string sent by the server really annoying.
- I added a few fields to the Plugin type that are used to hook system calls while writing tests. I'm not sure how I feel about these, but I couldn't think of a better way to do those.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14854