### PR TITLE
MM-14742 Add ability for user to change their submitted score

### DIFF
--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -102,7 +102,7 @@
   revision = "1d33003b386959af197ba96475f198c114627b5e"
 
 [[projects]]
-  digest = "1:77c91150dbdad987cb9a3cce01cee3ebcfb05ab346f2e450009f4d2d6a53bf36"
+  digest = "1:7ec3c6a247b3683b0236dc67d3aec9fb361a0543b98a356a2c8673ce00a2d33b"
   name = "github.com/mattermost/mattermost-server"
   packages = [
     "mlog",
@@ -116,8 +116,7 @@
     "utils/markdown",
   ]
   pruneopts = "NUT"
-  revision = "dc70ab42034da17eaf23be5a86abae81b3f1cd21"
-  version = "v5.10.0"
+  revision = "2b6691e5ccc38b36e9a6113657ba5e53196e650d"
 
 [[projects]]
   digest = "1:18b773b92ac82a451c1276bd2776c1e55ce057ee202691ab33c8d6690efcc048"

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
-  version = "~5.10.0"
+  revision = "2b6691e5ccc38b36e9a6113657ba5e53196e650d"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/server/api.go
+++ b/server/api.go
@@ -136,11 +136,15 @@ func (p *Plugin) submitScore(w http.ResponseWriter, r *http.Request) {
 		// Still appear to the end user as if their feedback was actually sent
 	}
 
-	if appErr := p.markSurveyAnswered(userID, now); appErr != nil {
+	isFirstResponse, appErr := p.markSurveyAnswered(userID, now)
+	if appErr != nil {
 		p.API.LogWarn("Failed to mark survey as answered", "err", appErr)
 	}
 
-	p.CreateBotDMPost(userID, p.buildFeedbackRequestPost())
+	// Thank the user for their feedback when they first answer the survey
+	if isFirstResponse {
+		p.CreateBotDMPost(userID, p.buildFeedbackRequestPost())
+	}
 
 	// Send response to update score post
 	response := model.PostActionIntegrationResponse{


### PR DESCRIPTION
Uses the new functionality added in https://github.com/mattermost/mattermost-server/pull/10659 to save the previous score submitted by the user so that they can change the score after submitting it.

As per the spec, a change in a user's score is sent to Segment exactly the same as if it was the first time that the user selected something. Surveybot only thanks the user for their feedback when they first select a score though.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14742