### PR TITLE
MM-14876 Use KVCompareAndSet to add locking for HA

### DIFF
--- a/server/Gopkg.lock
+++ b/server/Gopkg.lock
@@ -102,7 +102,15 @@
   revision = "1d33003b386959af197ba96475f198c114627b5e"
 
 [[projects]]
-  digest = "1:7ec3c6a247b3683b0236dc67d3aec9fb361a0543b98a356a2c8673ce00a2d33b"
+  digest = "1:60ac67c5e4ea431ce6936f7d89a686013060e9963a8ed58dbc791b576ce8053c"
+  name = "github.com/mattermost/go-i18n"
+  packages = ["i18n"]
+  pruneopts = "NUT"
+  revision = "0dc1626d56435e9d605a29875701721c54bc9bbd"
+  version = "v1.10.0"
+
+[[projects]]
+  digest = "1:f15d85d14c5c37b8852a4b3ab6052b50a7cec7bbb2193fac2af9c7aafb576a67"
   name = "github.com/mattermost/mattermost-server"
   packages = [
     "mlog",
@@ -116,7 +124,7 @@
     "utils/markdown",
   ]
   pruneopts = "NUT"
-  revision = "2b6691e5ccc38b36e9a6113657ba5e53196e650d"
+  revision = "dce6cb601f15f27cb35fb37b6863ee4626df6d01"
 
 [[projects]]
   digest = "1:18b773b92ac82a451c1276bd2776c1e55ce057ee202691ab33c8d6690efcc048"
@@ -127,10 +135,9 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:07140002dbf37da92090f731b46fa47be4820b82fe5c14a035203b0e813d0ec2"
+  digest = "1:d6d44d2433c588ea2956f9f152ffb73893072750787c6f24bfa9db07eeef06c2"
   name = "github.com/nicksnyder/go-i18n"
   packages = [
-    "i18n",
     "i18n/bundle",
     "i18n/language",
     "i18n/translation",

--- a/server/Gopkg.toml
+++ b/server/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/mattermost/mattermost-server"
-  revision = "2b6691e5ccc38b36e9a6113657ba5e53196e650d"
+  revision = "dce6cb601f15f27cb35fb37b6863ee4626df6d01"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/server/activate.go
+++ b/server/activate.go
@@ -29,9 +29,15 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
+	now := p.now().UTC()
+
+	if err := p.clearStaleLocks(now); err != nil {
+		return err
+	}
+
 	p.API.LogDebug("NPS plugin activated")
 
-	now := p.now().UTC()
+	p.setActivated(true)
 
 	if upgraded, appErr := p.checkForServerUpgrade(now); appErr != nil {
 		return appErr
@@ -40,8 +46,6 @@ func (p *Plugin) OnActivate() error {
 
 		go p.checkForNextSurvey(now)
 	}
-
-	p.setActivated(true)
 
 	return nil
 }

--- a/server/activate_test.go
+++ b/server/activate_test.go
@@ -34,6 +34,7 @@ func TestOnActivate(t *testing.T) {
 		api.On("GetUserByUsername", "surveybot").Return(&model.User{Id: botUserID}, nil)
 		api.On("GetBot", botUserID, true).Return(&model.Bot{UserId: botUserID}, nil)
 		api.On("GetServerVersion").Return(serverVersion)
+		api.On("KVList", 0, 100).Return([]string{}, nil)
 		api.On("KVGet", fmt.Sprintf(SERVER_UPGRADE_KEY, serverVersion)).Return(mustMarshalJSON(&serverUpgrade{}), nil)
 		defer api.AssertExpectations(t)
 
@@ -65,6 +66,7 @@ func TestOnActivate(t *testing.T) {
 		api.On("GetUserByUsername", "surveybot").Return(&model.User{Id: botUserID}, nil)
 		api.On("GetBot", botUserID, true).Return(&model.Bot{UserId: botUserID}, nil)
 		api.On("GetServerVersion").Return(serverVersion)
+		api.On("KVList", 0, 100).Return([]string{}, nil)
 		api.On("KVGet", fmt.Sprintf(SERVER_UPGRADE_KEY, serverVersion)).Return(nil, &model.AppError{})
 		defer api.AssertExpectations(t)
 
@@ -85,7 +87,7 @@ func TestOnActivate(t *testing.T) {
 		assert.NotNil(t, p.client)
 	})
 
-	t.Run("should return an error when get Surveybot", func(t *testing.T) {
+	t.Run("should return an error when unable to get Surveybot", func(t *testing.T) {
 		api := makeAPIMock()
 		api.On("GetConfig").Return(&model.Config{
 			LogSettings: model.LogSettings{

--- a/server/lock.go
+++ b/server/lock.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"time"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+const (
+	// LOCK_KEY is used to prevent multiple instances of the plugin from scheduling surveys in parallel.
+	LOCK_KEY = "Lock"
+
+	// USER_LOCK_KEY is used to prevent multiple instances of the plugin from responding to a single user's requests
+	// in parallel.
+	USER_LOCK_KEY = "UserLock-%s"
+
+	// LOCK_EXPIRATION is how long a lock can be held before it will be automatically released the next time that an
+	// instance of the plugin is started up.
+	LOCK_EXPIRATION = time.Hour
+)
+
+var userLockPattern = regexp.MustCompile("^UserLock-.{26}$")
+
+func (p *Plugin) tryLock(key string, now time.Time) (bool, *model.AppError) {
+	b, err := json.Marshal(now)
+	if err != nil {
+		return false, &model.AppError{Message: err.Error()}
+	}
+
+	return p.API.KVCompareAndSet(key, nil, b)
+}
+
+func (p *Plugin) unlock(key string) *model.AppError {
+	return p.API.KVDelete(key)
+}
+
+// clearStaleLocks deletes any lock entries that have been held for a long time since that likely means that the routine
+// that held them died without properly releasing them.
+func (p *Plugin) clearStaleLocks(now time.Time) *model.AppError {
+	page := 0
+	perPage := 100
+
+	for {
+		keys, err := p.API.KVList(page, perPage)
+		if err != nil {
+			return err
+		}
+
+		for _, key := range keys {
+			if key != LOCK_KEY && !userLockPattern.MatchString(key) {
+				continue
+			}
+
+			value, err := p.API.KVGet(key)
+			if err != nil {
+				return err
+			}
+
+			// Ignore any unmarshaling error in case the lock has gotten stuck in a really bad state
+			var t time.Time
+			_ = json.Unmarshal(value, &t)
+
+			if now.Sub(t) >= LOCK_EXPIRATION {
+				// There's no KVCompareAndDelete, so make sure we're the only ones modifying this lock
+				if set, err := p.API.KVCompareAndSet(key, value, []byte("releasing")); err != nil {
+					return err
+				} else if !set {
+					// Someone else has released or cleared the lock
+					continue
+				}
+
+				p.API.LogInfo("Freeing expired NPS lock", "key", key)
+
+				if err := p.API.KVDelete(key); err != nil {
+					return err
+				}
+			}
+		}
+
+		if len(keys) < perPage {
+			break
+		}
+
+		page += 1
+	}
+
+	return nil
+}

--- a/server/lock.go
+++ b/server/lock.go
@@ -64,7 +64,8 @@ func (p *Plugin) clearStaleLocks(now time.Time) *model.AppError {
 
 			if now.Sub(t) >= LOCK_EXPIRATION {
 				// There's no KVCompareAndDelete, so make sure we're the only ones modifying this lock
-				if set, err := p.API.KVCompareAndSet(key, value, []byte("releasing")); err != nil {
+				set, err := p.API.KVCompareAndSet(key, value, []byte("releasing"))
+				if err != nil {
 					return err
 				} else if !set {
 					// Someone else has released or cleared the lock

--- a/server/lock_test.go
+++ b/server/lock_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTryLock(t *testing.T) {
+	now := toDate(2019, time.February, 18)
+
+	api := &plugintest.API{}
+	api.On("KVCompareAndSet", LOCK_KEY, []byte(nil), mustMarshalJSON(now)).Return(true, nil)
+	defer api.AssertExpectations(t)
+
+	p := &Plugin{}
+	p.SetAPI(api)
+
+	locked, err := p.tryLock(LOCK_KEY, now)
+
+	assert.Equal(t, true, locked)
+	assert.Nil(t, err)
+}
+
+func TestUnlock(t *testing.T) {
+	api := &plugintest.API{}
+	api.On("KVDelete", LOCK_KEY).Return(nil)
+	defer api.AssertExpectations(t)
+
+	p := &Plugin{}
+	p.SetAPI(api)
+
+	err := p.unlock(LOCK_KEY)
+
+	assert.Nil(t, err)
+}
+
+func TestClearStaleLocks(t *testing.T) {
+	now := toDate(2019, time.February, 18)
+	serverVersion := "5.10.0"
+	userID := model.NewId()
+
+	userLockKey := fmt.Sprintf(USER_LOCK_KEY, userID)
+
+	t.Run("shouldn't affect KV store entries that aren't locks", func(t *testing.T) {
+		api := &plugintest.API{}
+		api.On("KVList", 0, 100).Return([]string{
+			fmt.Sprintf(ADMIN_DM_NOTICE_KEY, userID, serverVersion),
+			LAST_ADMIN_NOTICE_KEY,
+			fmt.Sprintf(SERVER_UPGRADE_KEY, serverVersion),
+			fmt.Sprintf(SURVEY_KEY, serverVersion),
+			fmt.Sprintf(USER_SURVEY_KEY, userID),
+			"something else",
+		}, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.clearStaleLocks(now)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("shouldn't affect locks that were acquired recently", func(t *testing.T) {
+		lockValue := mustMarshalJSON(now.Add(-1 * time.Minute))
+		userLockValue := mustMarshalJSON(now.Add(-5 * time.Minute))
+
+		api := &plugintest.API{}
+		api.On("KVList", 0, 100).Return([]string{
+			LOCK_KEY,
+			userLockKey,
+		}, nil)
+		api.On("KVGet", LOCK_KEY).Return(lockValue, nil)
+		api.On("KVGet", userLockKey).Return(userLockValue, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.clearStaleLocks(now)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("should clear locks that were acquired too long ago", func(t *testing.T) {
+		lockValue := mustMarshalJSON(now.Add(-1 * time.Hour))
+		userLockValue := mustMarshalJSON(now.Add(-5 * time.Hour))
+
+		api := &plugintest.API{}
+		api.On("KVList", 0, 100).Return([]string{
+			LOCK_KEY,
+			userLockKey,
+		}, nil)
+		api.On("KVGet", LOCK_KEY).Return(lockValue, nil)
+		api.On("KVCompareAndSet", LOCK_KEY, lockValue, []byte("releasing")).Return(true, nil)
+		api.On("KVDelete", LOCK_KEY).Return(nil)
+		api.On("KVGet", userLockKey).Return(userLockValue, nil)
+		api.On("KVCompareAndSet", userLockKey, userLockValue, []byte("releasing")).Return(true, nil)
+		api.On("KVDelete", userLockKey).Return(nil)
+		api.On("LogInfo", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.clearStaleLocks(now)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("should clear locks that weren't properly freed before", func(t *testing.T) {
+		lockValue := []byte("releasing")
+
+		api := &plugintest.API{}
+		api.On("KVList", 0, 100).Return([]string{
+			LOCK_KEY,
+		}, nil)
+		api.On("KVGet", LOCK_KEY).Return(lockValue, nil)
+		api.On("KVCompareAndSet", LOCK_KEY, lockValue, []byte("releasing")).Return(true, nil)
+		api.On("KVDelete", LOCK_KEY).Return(nil)
+		api.On("LogInfo", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.clearStaleLocks(now)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("should not try to delete an old lock that was modified by another thread", func(t *testing.T) {
+		lockValue := mustMarshalJSON(now.Add(-1 * time.Hour))
+
+		api := &plugintest.API{}
+		api.On("KVList", 0, 100).Return([]string{
+			LOCK_KEY,
+		}, nil)
+		api.On("KVGet", LOCK_KEY).Return(lockValue, nil)
+		api.On("KVCompareAndSet", LOCK_KEY, lockValue, []byte("releasing")).Return(false, nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.clearStaleLocks(now)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("should check multiple pages of keys", func(t *testing.T) {
+		keys := make([]string, 100)
+		for i := 0; i < 100; i++ {
+			keys[i] = fmt.Sprintf("key%d", i)
+		}
+
+		api := &plugintest.API{}
+		api.On("KVList", 0, 100).Return(keys, nil)
+		api.On("KVList", 1, 100).Return(keys, nil)
+		api.On("KVList", 2, 100).Return(keys[:40], nil)
+		defer api.AssertExpectations(t)
+
+		p := &Plugin{}
+		p.SetAPI(api)
+
+		err := p.clearStaleLocks(now)
+
+		assert.Nil(t, err)
+	})
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -31,9 +31,6 @@ const (
 	USER_SURVEY_KEY = "UserSurvey-%s"
 
 	SURVEYBOT_DESCRIPTION = "Surveybot collects user feedback to improve Mattermost. [Learn more](https://mattermost.com/pl/default-nps)."
-
-	DEFAULT_UPGRADE_CHECK_MAX_DELAY = 2 * time.Minute
-	DEAFULT_USER_SURVEY_MAX_DELAY   = 3 * time.Second
 )
 
 type Plugin struct {
@@ -52,24 +49,9 @@ type Plugin struct {
 	// activated is used to track whether or not OnActivate has initialized the plugin state.
 	activated bool
 
-	// surveyLock is used to prevent multiple threads from accessing checkForNextSurvey at the same time.
-	surveyLock sync.Mutex
-
-	// connectedLock is used to prevent multiple connected requests from being handled at the same time in order to
-	// prevent users from receiving duplicate Surveybot DMs.
-	connectedLock sync.Mutex
-
 	botUserID string
 
 	client *analytics.Client
-
-	// upgradeCheckMaxDelay adds a short delay to checkForNextSurvey calls to mitigate against race conditions caused
-	// by multiple servers restarting at the same time after an upgrade.
-	upgradeCheckMaxDelay time.Duration
-
-	// userSurveyMaxDelay adds a short delay when checking whether the user needs to receive DMs notifying them of a new
-	// NPS survey.
-	userSurveyMaxDelay time.Duration
 
 	// blockSegmentEvents prevents the plugin from sending events to Segment during testing.
 	blockSegmentEvents bool
@@ -83,9 +65,6 @@ type Plugin struct {
 
 func NewPlugin() *Plugin {
 	return &Plugin{
-		upgradeCheckMaxDelay: DEFAULT_UPGRADE_CHECK_MAX_DELAY,
-		userSurveyMaxDelay:   DEAFULT_USER_SURVEY_MAX_DELAY,
-
 		now:      time.Now,
 		readFile: ioutil.ReadFile,
 	}


### PR DESCRIPTION
This replaces the locks that were part of the `Plugin` struct as well as the hacky delays meant to mitigate against having two plugin instances modifying user state at the same time.

A few important things to note:
1. There's two different types of locking used: one lock for checking whether or not a survey needs to be scheduled and an arbitrary number of per-user locks for checking their survey state and seeing if they need to receive any DMs.
2. Since there's no way to make entries expire if they were added using `KVCompareAndSet`, I made it so that when the plugin starts up, it will check for any locks that were acquired over an hour ago, just in case a previous plugin instance died while holding a lock. I thought about using `KVSetWithExpiry` after the `KVCompareAndSet` to accomplish this, but I felt like that might cause some weirdness because `KVCompareAndSet` treats an expired value differently from a deleted one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14876