### PR TITLE
MM-15745 Rename user_id field in Segment to user_actual_id

### DIFF
--- a/server/segment.go
+++ b/server/segment.go
@@ -58,7 +58,7 @@ func (p *Plugin) sendToSegment(event string, userID string, timestamp int64, pro
 
 func (p *Plugin) getEventProperties(userID string, timestamp int64, other map[string]interface{}) map[string]interface{} {
 	properties := map[string]interface{}{
-		"user_id":        userID,
+		"user_actual_id": userID,
 		"timestamp":      timestamp,
 		"server_version": p.API.GetServerVersion(), // Note that this calls the API directly, so it gets the full version (including patch version)
 		"server_id":      p.API.GetDiagnosticId(),

--- a/server/segment_test.go
+++ b/server/segment_test.go
@@ -47,7 +47,7 @@ func TestGetEventProperties(t *testing.T) {
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userID,
+				"user_actual_id":      userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
@@ -79,7 +79,7 @@ func TestGetEventProperties(t *testing.T) {
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userID,
+				"user_actual_id":      userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": int64(0),
@@ -107,7 +107,7 @@ func TestGetEventProperties(t *testing.T) {
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userID,
+				"user_actual_id":      userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
@@ -136,7 +136,7 @@ func TestGetEventProperties(t *testing.T) {
 				return api
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userID,
+				"user_actual_id":      userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,
@@ -172,7 +172,7 @@ func TestGetEventProperties(t *testing.T) {
 				"other_2": "abcd",
 			},
 			Expected: map[string]interface{}{
-				"user_id":             userID,
+				"user_actual_id":      userID,
 				"timestamp":           timestamp,
 				"server_version":      serverVersion,
 				"server_install_date": systemInstallDate,


### PR DESCRIPTION
The name `user_id` conflicts with Segment's "user ID" which is actually the server's diagnostic ID. Using a different name for the user ID prevents that from being overwritten. This matches the naming convention of some of our other diagnostics as well

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15745