### PR TITLE
MM-14804 Trim cookie values when looking for the CSRF token 

### DIFF
--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -35,7 +35,8 @@ export class Client {
 }
 
 function getCSRFFromCookie() {
-    const cookies = document.cookie.split(';');
+    const cookies = document.cookie.split(';').map((cookie) => cookie.trim());
+
     for (const cookie of cookies) {
         if (cookie.startsWith('MMCSRF=')) {
             return cookie.replace('MMCSRF=', '');


### PR DESCRIPTION
The `document.cookie` has whitespace after each cookie value, so the `startsWith` would sometimes fail to identify the correct cookie

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14804