### PR TITLE
MM-8647 Change system console links to open in a new tab

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -15,13 +15,13 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "A net promoter score survey measures user satisfaction. [Learn more](https://mattermost.com/pl/default-nps) about net promoter score surveys.",
+        "header": "A net promoter score survey measures user satisfaction. [Learn more](!https://mattermost.com/pl/default-nps) about net promoter score surveys.",
         "footer": "",
         "settings": [{
             "key": "EnableSurvey",
             "display_name": "Enable Net Promoter Score Survey",
             "type": "bool",
-            "help_text": "When true, a [net promoter score survey](https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](https://mattermost.com/pl/default-nps-privacy-policy) for more information on the collection and use of information received through our services.",
+            "help_text": "When true, a [net promoter score survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://mattermost.com/pl/default-nps-privacy-policy) for more information on the collection and use of information received through our services.",
             "default": true
         }]
     }


### PR DESCRIPTION
Followup to the much earlier fix to make it so that the help text for plugins could support Markdown. I added the ability for the plugin help text to open links in a new tab, but I forgot to actually implement it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8647

#### Related Tickets
https://github.com/mattermost/mattermost-webapp/pull/2912
