### PR TITLE
MM-16611: leverage relative action URLs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "name": "Net Promoter Score",
     "description": "This plugin sends Net Promoter Score surveys to gather user feedback on Mattermost.",
     "version": "1.0.1",
-    "min_server_version": "5.12.0",
+    "min_server_version": "5.14.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -101,9 +101,6 @@ func TestSubmitScore(t *testing.T) {
 
 		// Disabling diagnostics allows the handler to run, but prevents data from being sent to Segment
 		api.On("GetConfig").Return(&model.Config{
-			ServiceSettings: model.ServiceSettings{
-				SiteURL: model.NewString("https://mattermost.example.com"),
-			},
 			LogSettings: model.LogSettings{
 				EnableDiagnostics: model.NewBool(false),
 			},

--- a/server/survey.go
+++ b/server/survey.go
@@ -378,14 +378,12 @@ func (p *Plugin) buildSurveyPostAction() *model.PostAction {
 		})
 	}
 
-	siteURL := *p.API.GetConfig().ServiceSettings.SiteURL
-
 	return &model.PostAction{
 		Name:    "Select an option...",
 		Type:    model.POST_ACTION_TYPE_SELECT,
 		Options: options,
 		Integration: &model.PostActionIntegration{
-			URL: fmt.Sprintf("%s/plugins/%s/api/v1/score", siteURL, manifest.Id),
+			URL: fmt.Sprintf("/plugins/%s/api/v1/score", manifest.Id),
 		},
 	}
 }

--- a/server/survey_test.go
+++ b/server/survey_test.go
@@ -602,7 +602,6 @@ func TestCheckForSurveyDM(t *testing.T) {
 			StartAt:       now,
 		}), nil)
 		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, nil)
-		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
 		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id), newSurveyStateBytes).Return(nil)
@@ -627,7 +626,6 @@ func TestCheckForSurveyDM(t *testing.T) {
 			StartAt:       now,
 		}), nil)
 		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, nil)
-		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
 		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id), newSurveyStateBytes).Return(&model.AppError{})
@@ -652,7 +650,6 @@ func TestCheckForSurveyDM(t *testing.T) {
 			StartAt:       now,
 		}), nil)
 		api.On("KVGet", fmt.Sprintf(USER_SURVEY_KEY, user.Id)).Return(nil, nil)
-		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(nil, &model.AppError{})
 		defer api.AssertExpectations(t)
@@ -680,7 +677,6 @@ func TestCheckForSurveyDM(t *testing.T) {
 			SentAt:        now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS),
 			AnsweredAt:    now.Add(-1 * MIN_TIME_BETWEEN_USER_SURVEYS),
 		}), nil)
-		api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: model.NewString("https://mattermost.example.com")}})
 		api.On("GetDirectChannel", user.Id, botUserID).Return(&model.Channel{}, nil)
 		api.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID}, nil)
 		api.On("KVSet", fmt.Sprintf(USER_SURVEY_KEY, user.Id), newSurveyStateBytes).Return(nil)


### PR DESCRIPTION
[MM-10982](https://mattermost.atlassian.net/browse/MM-10982) introduced support for relative post integration action URLs, reducing the overhead on plugins when building the actions and simultaneously enabling SiteURL-agnostic action handling with a plugin. Leverage this functionality in the NPS plugin for new posts. Existing posts will continue to use the absolute URL embedded in the post metadata.

Note that this functionality requires 5.14.0, now reflected in plugin.json.