### PR TITLE
MM-16285 Rename NPS surveys to user satisfaction surveys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Mattermost Net Promoter Score Plugin
+# Mattermost User Satisfaction Survey Plugin
 
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-nps/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-nps)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-nps/master.svg)](https://codecov.io/gh/mattermost/mattermost-plugin-nps)
 
-A plugin for Mattermost to gather user feedback about Mattermost itself using NPS (Net Promoter Score) surveys.
+A plugin for Mattermost to gather user feedback about Mattermost itself using user satisfaction surveys.
 
 ## Installation
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "com.mattermost.nps",
-    "name": "Net Promoter Score",
-    "description": "This plugin sends Net Promoter Score surveys to gather user feedback on Mattermost.",
+    "name": "User Satisfaction Surveys",
+    "description": "This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost.",
     "version": "1.0.2",
     "min_server_version": "5.14.0",
     "server": {
@@ -15,13 +15,13 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "A net promoter score survey measures user satisfaction. [Learn more](!https://mattermost.com/pl/default-nps) about net promoter score surveys.",
+        "header": "Mattermost sends user satisfaction surveys to gather feedback and improve product quality. [Learn more](!https://mattermost.com/pl/default-nps) about user satisfaction surveys.",
         "footer": "",
         "settings": [{
             "key": "EnableSurvey",
-            "display_name": "Enable Net Promoter Score Survey",
+            "display_name": "Enable User Satisfaction Survey",
             "type": "bool",
-            "help_text": "When true, a [net promoter score survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://mattermost.com/pl/default-nps-privacy-policy) for more information on the collection and use of information received through our services.",
+            "help_text": "When true, a [user satisfaction survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://about.mattermost.com/default-privacy-policy) for more information on the collection and use of information received through our services.",
             "default": true
         }]
     }

--- a/server/activate.go
+++ b/server/activate.go
@@ -8,10 +8,10 @@ import (
 )
 
 func (p *Plugin) OnActivate() error {
-	p.API.LogDebug("Activating NPS plugin")
+	p.API.LogDebug("Activating plugin")
 
 	if !p.canSendDiagnostics() {
-		errMsg := "Not activating NPS plugin because diagnostics are disabled"
+		errMsg := "Not activating plugin because diagnostics are disabled"
 		p.API.LogError(errMsg)
 		return errors.New(errMsg)
 	}
@@ -35,7 +35,7 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
-	p.API.LogDebug("NPS plugin activated")
+	p.API.LogDebug("Plugin activated")
 
 	p.setActivated(true)
 

--- a/server/lock.go
+++ b/server/lock.go
@@ -72,7 +72,7 @@ func (p *Plugin) clearStaleLocks(now time.Time) *model.AppError {
 					continue
 				}
 
-				p.API.LogInfo("Freeing expired NPS lock", "key", key)
+				p.API.LogInfo("Freeing expired lock", "key", key)
 
 				if err := p.API.KVDelete(key); err != nil {
 					return err

--- a/server/segment.go
+++ b/server/segment.go
@@ -110,7 +110,7 @@ func (p *Plugin) isUserTeamAdmin(user *model.User) bool {
 	for {
 		teamMembers, err := p.API.GetTeamMembersForUser(user.Id, page, perPage)
 		if err != nil {
-			p.API.LogWarn("Failed to get role for user when sending NPS results")
+			p.API.LogWarn("Failed to get role for user when sending survey results")
 			return false
 		}
 

--- a/server/survey.go
+++ b/server/survey.go
@@ -147,16 +147,16 @@ func (p *Plugin) sendAdminNoticeEmails(admins []*model.User) {
 
 	var buf bytes.Buffer
 	if err := adminEmailBodyTemplate.Execute(&buf, bodyProps); err != nil {
-		p.API.LogError("Failed to prepare NPS survey notification email", "err", err)
+		p.API.LogError("Failed to prepare survey notification email", "err", err)
 		return
 	}
 	body := buf.String()
 
 	for _, admin := range admins {
-		p.API.LogDebug("Sending NPS survey notification email", "email", admin.Email)
+		p.API.LogDebug("Sending survey notification email", "email", admin.Email)
 
 		if err := p.API.SendMail(admin.Email, subject, body); err != nil {
-			p.API.LogError("Failed to send NPS survey notification email", "email", admin.Email, "err", err)
+			p.API.LogError("Failed to send survey notification email", "email", admin.Email, "err", err)
 		}
 	}
 }

--- a/server/survey_templates.go
+++ b/server/survey_templates.go
@@ -4,7 +4,7 @@ import (
 	"html/template"
 )
 
-const adminEmailSubject = "[%s] Net Promoter Score survey scheduled in %d days"
+const adminEmailSubject = "[%s] User Satisfaction Survey scheduled in %d days"
 
 var adminEmailBodyTemplate = template.Must(template.New("emailBody").Parse(`
 <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-top: 20px; line-height: 1.7; color: #555;">
@@ -24,9 +24,9 @@ var adminEmailBodyTemplate = template.Must(template.New("emailBody").Parse(`
                                     <table border="0" cellpadding="0" cellspacing="0" style="padding: 20px 50px 0; text-align: center; margin: 0 auto">
                                         <tr>
                                             <td style="padding: 0 0 20px;">
-                                                <h2 style="font-weight: normal; margin-top: 10px;">Net Promoter Survey Scheduled</h2>
-                                                <p>Mattermost is introducing feedback surveys to measure user satisfaction and improve product quality. Surveys will start to be sent to users in <strong>{{.DaysUntilSurvey}} days</strong>.</p>
-                                                <p><a href="{{.SiteURL}}/admin_console/plugins/plugin_{{.PluginID}}">Click here</a> to disable or learn more about Net Promoter surveys.</p>
+                                                <h2 style="font-weight: normal; margin-top: 10px;"><a href="https://mattermost.com/pl/default-nps">User Satisfaction Survey</a> Scheduled</h2>
+                                                <p>Mattermost sends quarterly in-product user satisfaction surveys to gather feedback from users and improve product quality. Surveys will be received by users in <strong>{{.DaysUntilSurvey}} days</strong>.</p>
+                                                <p>Click <a href="{{.SiteURL}}/admin_console/plugins/plugin_{{.PluginID}}">here</a> to disable or learn more about user satisfaction surveys. Please refer to our <a href="https://about.mattermost.com/default-privacy-policy">privacy policy</a> for more information on the collection and use of information received through our services.</p>
                                             </td>
                                         </tr>
                                         <tr>
@@ -55,7 +55,7 @@ var adminEmailBodyTemplate = template.Must(template.New("emailBody").Parse(`
 
 const adminDMBody = `Mattermost uses feedback surveys to measure user satisfaction and improve product quality. User surveys will start to be sent on %s.
 
-[Click here](/admin_console/plugins/plugin_%s) to disable or learn more about Net Promoter Score Surveys.
+[Click here](/admin_console/plugins/plugin_%s) to disable or learn more about user satisfaction surveys.
 
 *This message is only visible to System Admins.*`
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webapp",
   "version": "0.0.1",
-  "description": "This plugin sends Net Promoter Score surveys to gather user feedback on Mattermost.",
+  "description": "This plugin sends User satisfaction surveys to gather user feedback on Mattermost.",
   "main": "src/index.js",
   "scripts": {
     "build": "webpack --mode=production",


### PR DESCRIPTION
We've renamed Net Promoter Score surveys to user satisfaction surveys since that's a less technical term for them. The internal name of the plugin isn't changing.

## Admin Notifications
![Screen Shot 2019-07-18 at 12 53 25 PM](https://user-images.githubusercontent.com/3277310/61477371-1754d900-a95d-11e9-92a1-a61573c47e14.png)
![Screen Shot 2019-07-18 at 12 53 33 PM](https://user-images.githubusercontent.com/3277310/61477304-ec6a8500-a95c-11e9-896c-6acbb99f82cb.png)

## System Console
![Screen Shot 2019-07-18 at 12 53 45 PM](https://user-images.githubusercontent.com/3277310/61477325-f8eedd80-a95c-11e9-9301-6445faa41448.png)
![Screen Shot 2019-07-18 at 12 53 51 PM](https://user-images.githubusercontent.com/3277310/61477328-fd1afb00-a95c-11e9-9d0a-3199ddd18250.png)
![Screen Shot 2019-07-18 at 12 54 00 PM](https://user-images.githubusercontent.com/3277310/61477335-ff7d5500-a95c-11e9-83f8-2d60f631c4ca.png)

