### PR TITLE
MM-15785 Only call connected API if user is logged in

### DIFF
--- a/webapp/jest.config.js
+++ b/webapp/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    clearMocks: true,
     globals: {
         ReactBootstrap: {},
     },

--- a/webapp/src/actions.js
+++ b/webapp/src/actions.js
@@ -1,8 +1,14 @@
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
 import * as ActionTypes from './action_types';
 
 export function connected(client) {
-    return () => {
-        client.connected();
+    return (dispatch, getState) => {
+        const currentUserId = getCurrentUserId(getState());
+
+        if (currentUserId) {
+            client.connected();
+        }
     };
 }
 

--- a/webapp/src/actions.test.js
+++ b/webapp/src/actions.test.js
@@ -1,0 +1,35 @@
+import {connected} from './actions';
+
+describe('connected', () => {
+    const client = {
+        connected: jest.fn(),
+    };
+
+    test('should call connected API if the user is logged in', () => {
+        const getState = () => ({
+            entities: {
+                users: {
+                    currentUserId: 'user1',
+                },
+            },
+        });
+
+        connected(client)(null, getState);
+
+        expect(client.connected).toHaveBeenCalled();
+    });
+
+    test('should do nothing if the user is not logged in', () => {
+        const getState = () => ({
+            entities: {
+                users: {
+                    currentUserId: '',
+                },
+            },
+        });
+
+        connected(client)(null, getState);
+
+        expect(client.connected).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
This stops a harmless JS error that happens when the app is opened but the user hasn't logged in yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17585