### PR TITLE
Add more manifest metadata

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,6 +2,8 @@
     "id": "com.mattermost.nps",
     "name": "User Satisfaction Surveys",
     "description": "This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost.",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-nps",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-nps/issues",
     "version": "1.0.3",
     "min_server_version": "5.16.0",
     "server": {


### PR DESCRIPTION
#### Summary
Add `homepage_url` and `support_url` to the manifest. `support_url` is not jet used in the webapp, but there is no downside of defining it already.

I've tested the changes locally and can confirm that the link to the `homepage_url` is correctly shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21918
