### PR TITLE
Automate backend manifest read

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -3,10 +3,9 @@
 
 package main
 
-var manifest = struct {
-	ID      string
-	Version string
-}{
-	ID:      "com.mattermost.nps",
-	Version: "1.2.0",
-}
+import (
+	root "github.com/mattermost/mattermost-plugin-nps/server"
+)
+
+// the manifest is automatically generated from plugin.json at the root of the project
+var manifest = root.Manifest

--- a/server/survey.go
+++ b/server/survey.go
@@ -147,7 +147,7 @@ func (p *Plugin) sendAdminNoticeEmails(admins []*model.User) {
 	subject := fmt.Sprintf(adminEmailSubject, *config.TeamSettings.SiteName, DaysUntilSurvey)
 
 	bodyProps := map[string]interface{}{
-		"PluginID":        manifest.ID,
+		"PluginID":        manifest.Id,
 		"SiteURL":         *config.ServiceSettings.SiteURL,
 		"DaysUntilSurvey": DaysUntilSurvey,
 	}
@@ -277,7 +277,7 @@ func (p *Plugin) sendAdminNoticeDM(user *model.User, notice *adminNotice) *model
 
 func (p *Plugin) buildAdminNoticePost(surveyStartAt time.Time) *model.Post {
 	return &model.Post{
-		Message: fmt.Sprintf(adminDMBody, surveyStartAt.Format("January 2, 2006"), manifest.ID),
+		Message: fmt.Sprintf(adminDMBody, surveyStartAt.Format("January 2, 2006"), manifest.Id),
 		Type:    "custom_nps_admin_notice",
 	}
 }
@@ -386,7 +386,7 @@ func (p *Plugin) buildDisableAction() *model.PostAction {
 		Name: "Disable",
 		Type: model.PostActionTypeButton,
 		Integration: &model.PostActionIntegration{
-			URL: fmt.Sprintf("/plugins/%s/api/v1/disable_for_user", manifest.ID),
+			URL: fmt.Sprintf("/plugins/%s/api/v1/disable_for_user", manifest.Id),
 		},
 	}
 }
@@ -412,7 +412,7 @@ func (p *Plugin) buildSurveyPostAction() *model.PostAction {
 		Type:    model.PostActionTypeSelect,
 		Options: options,
 		Integration: &model.PostActionIntegration{
-			URL: fmt.Sprintf("/plugins/%s/api/v1/score", manifest.ID),
+			URL: fmt.Sprintf("/plugins/%s/api/v1/score", manifest.Id),
 		},
 	}
 }

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -27,7 +27,7 @@ func (p *Plugin) initTracker() {
 			enableDiagnostics = *configValue
 		}
 	}
-	p.tracker = telemetry.NewTracker(p.client, p.API.GetDiagnosticId(), p.API.GetServerVersion(), manifest.ID, manifest.Version, "nps", enableDiagnostics)
+	p.tracker = telemetry.NewTracker(p.client, p.API.GetDiagnosticId(), p.API.GetServerVersion(), manifest.Id, manifest.Version, "nps", enableDiagnostics)
 }
 
 func (p *Plugin) sendScore(score int, userID string, timestamp int64) {


### PR DESCRIPTION
#### Summary
QoL improvement for maintainer

The `plugin.go` file at the project's root reads `plugin.json` automatically, but we were not using it.
With this change, we would have to only edit `plugin.json` to change the plugin version (instead of plugin.json+`/server/manifest.go`)

#### Ticket Link
N/A

