### PR TITLE
[MM-49064] plugin don't report feedback since 1.3.0

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -3,3 +3,5 @@ ifndef MM_RUDDER_WRITE_KEY
   MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
 endif
 LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
+
+GO_BUILD_FLAGS = -ldflags '$(LDFLAGS)'


### PR DESCRIPTION
#### Summary
While upgrading the Makefile I did not realize that the LDFLAGS variable is not used anymore. As a consequence, during CI we were not injecting the prod rudder key. This PR inject the LDFLAGS into the GO_BUILD_FLAGS so that we compile the project with the flags set.

**Note**: This is 1.3.1 worthy and we might want to tag this ASAP after merge.

@stevemudie QA steps are, as always with NPS, super fun :D 

1. Create a cloud server on mattermost with `/cloud create YOURNAME-test-cloud-nps --image mattermost/mm-ee-cloud --version cloud-2022-12-01-1`
1. login as sysadmin (credentials provided by the cloud bot)
1. Send a feedback to the feedbackbot
1. Go to the server log (System Console > Server Logs). You should find a line containing `Failed to read writeKey from header`. This validates that there is indeed an error with the current version.
1. In the System Console, go to “Plugins” and Remove the User Satisfaction Survey plugin
1. Visit https://app.circleci.com/pipelines/github/mattermost/mattermost-plugin-nps/336/workflows/fdba5a90-9bdc-4623-b081-cc13d62f9824/jobs/1018/artifacts and download dist/com.mattermost.nps-1.3.0.tar.gz. This is the plugin built from my latest PR containing the fix
1. Upload the plugin you just downloaded in your mattermost instance (System Console > Plugins; Upload Plugin field)
1. Wait until it’s uploaded, then at the bottom of this page you must manually Enable the plugin
1. Repeat steps 3 and 4, but this time no error message appears.
1. When you are done, don't forget to `/cloud delete YOURNAME-test-cloud-nps`!

Sadly we have no way to validate that the message is indeed sent in rudder, but the lack of an error message is encouraging!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49064
